### PR TITLE
Fix: Resolve encoding crash due to VRAM overflow and backpressure

### DIFF
--- a/src/lib/media-compositor/media-compositor.ts
+++ b/src/lib/media-compositor/media-compositor.ts
@@ -7,6 +7,7 @@ import { precomputeFFTData, getFrameAtTime } from "@/lib/audio/fft-precompute";
 import { ExportProgressTracker, type ActivePhase } from "./export-progress-tracker";
 
 const frameSize = 20;
+const maxEncodeQueueSize = 6;
 
 type ExportPhase = "FFT" | "Audio Render" | "Audio Encode" | "Video Render" | "Video Encode";
 
@@ -105,7 +106,7 @@ export class MediaCompositor {
   async composite() {
     await this.#muxer.start();
     this.#renderAudio();
-    this.#renderVideo();
+    await this.#renderVideo();
 
     // Start encode timers now that render loops are done and flush begins
     this.#progress.startTimer("Audio Encode");
@@ -147,7 +148,7 @@ export class MediaCompositor {
     }
   }
 
-  #renderVideo() {
+  async #renderVideo() {
     const ctx = this.#canvas.getContext("2d");
     if (!ctx) throw new Error("Failed to get context");
 
@@ -189,6 +190,15 @@ export class MediaCompositor {
       frame.close();
       this.#videoEncodeCount++;
       this.#progress.increment("Video Encode");
+
+      // --- Backpressure control logic ---
+      // If the encoder's queue size exceeds the threshold,
+      // pause the loop (yield) until the GPU processes some frames and emits a 'dequeue' event.
+      if (this.#videoEncoder.encodeQueueSize > maxEncodeQueueSize) {
+        await new Promise<void>((resolve) => {
+          this.#videoEncoder.addEventListener("dequeue", () => resolve(), { once: true });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
When exporting high-resolution videos (e.g., 1080p), the application frequently crashed with an `EncodingError`. After investigation, I found that the synchronous `#renderVideo` loop flooded the GPU encoder with frames faster than it could process them, leading to:
1. VRAM saturation (GPU memory overflow).
2. TDR (Timeout Detection and Recovery) event triggered by Windows, causing a screen flicker and crash.
3. The lack of backpressure control in the encoding pipeline.

## Solution
I implemented backpressure control and made the rendering pipeline asynchronous to ensure the browser/GPU handles frames at a manageable rate:

1. Added `async` to `#renderVideo` and implemented a wait mechanism using `this.#videoEncoder.encodeQueueSize`.
2. Updated the `composite` method to `await` the rendering process, ensuring frames are processed sequentially without overwhelming the hardware.

## Results
- Stability: Resolved the `EncodingError` even at 1080p/60fps.
- Performance: Encoding is now much smoother, and the GPU memory usage remains stable during the entire process.
- Efficiency: The rendering loop is now properly synchronized with the encoding queue.

Thanks for the great project! I hope this contribution helps others with similar hardware limitations.