### PR TITLE
fix: correct export ETA for concurrently progressing encode phases

### DIFF
--- a/src/lib/media-compositor/export-progress-tracker.ts
+++ b/src/lib/media-compositor/export-progress-tracker.ts
@@ -5,8 +5,12 @@ interface PhaseConfig<T extends string> {
   total: number;
   /** Return actual completed count (may differ from reported count due to async queues) */
   getCompleted?: () => number;
-  /** If true, timer won't auto-start on increment/set. Call startTimer() explicitly. */
-  deferTimer?: boolean;
+}
+
+interface PhaseTimer {
+  start: number;
+  /** Completed count when the timer started; ETA is derived from progress made since then */
+  baseline: number;
 }
 
 export interface ActivePhase {
@@ -20,7 +24,7 @@ export interface ActivePhase {
 export class ExportProgressTracker<T extends string> {
   #phases: PhaseConfig<T>[] = [];
   #counts = new Map<T, number>();
-  #phaseStartTimes = new Map<T, number>();
+  #timers = new Map<T, PhaseTimer>();
   #onProgress: (progress: number, activePhase?: ActivePhase) => void;
 
   constructor(onProgress: (progress: number, activePhase?: ActivePhase) => void) {
@@ -30,11 +34,6 @@ export class ExportProgressTracker<T extends string> {
   addPhase(phase: PhaseConfig<T>) {
     this.#phases.push(phase);
     this.#counts.set(phase.name, 0);
-  }
-
-  /** Explicitly start the timer for a phase (for deferred phases) */
-  startTimer(phaseName: T) {
-    this.#phaseStartTimes.set(phaseName, performance.now());
   }
 
   /** Increment progress for a phase by 1 */
@@ -67,10 +66,13 @@ export class ExportProgressTracker<T extends string> {
   }
 
   #autoStartTimer(phaseName: T) {
-    if (this.#phaseStartTimes.has(phaseName)) return;
+    if (this.#timers.has(phaseName)) return;
     const phase = this.#phases.find((p) => p.name === phaseName);
-    if (phase?.deferTimer) return;
-    this.#phaseStartTimes.set(phaseName, performance.now());
+    if (!phase) return;
+    this.#timers.set(phaseName, {
+      start: performance.now(),
+      baseline: this.#getPhaseCompleted(phase),
+    });
   }
 
   get #totalWork() {
@@ -83,6 +85,11 @@ export class ExportProgressTracker<T extends string> {
   }
 
   #report = () => {
+    for (const phase of this.#phases) {
+      if (!this.#timers.has(phase.name) && this.#getPhaseCompleted(phase) > 0) {
+        this.#autoStartTimer(phase.name);
+      }
+    }
     const totalDone = this.#phases.reduce((sum, p) => sum + this.#getPhaseCompleted(p), 0);
     const progress = this.#totalWork > 0 ? totalDone / this.#totalWork : 0;
     this.#throttledReport(progress);
@@ -107,11 +114,12 @@ export class ExportProgressTracker<T extends string> {
 
   #getEta(phaseName: T, done: number, total: number): string {
     if (total === 0 || done === 0) return "--";
-    const startTime = this.#phaseStartTimes.get(phaseName);
-    if (startTime === undefined) return "--";
-    const elapsed = (performance.now() - startTime) / 1000;
-    const ratio = done / total;
-    const eta = (elapsed / ratio) * (1 - ratio);
+    const timer = this.#timers.get(phaseName);
+    if (timer === undefined) return "--";
+    const elapsed = (performance.now() - timer.start) / 1000;
+    const progressed = done - timer.baseline;
+    if (progressed <= 0 || elapsed <= 0) return "--";
+    const eta = (total - done) / (progressed / elapsed);
     const min = Math.floor(eta / 60);
     const sec = Math.floor(eta % 60);
     return `${min}m${sec.toString().padStart(2, "0")}s`;

--- a/src/lib/media-compositor/media-compositor.ts
+++ b/src/lib/media-compositor/media-compositor.ts
@@ -35,14 +35,12 @@ export class MediaCompositor {
       name: "Audio Encode",
       total: this.#totalAudioFrames,
       getCompleted: () => this.#audioEncodeCount - this.#audioEncoder.encodeQueueSize,
-      deferTimer: true,
     });
     this.#progress.addPhase({ name: "Video Render", total: this.#totalVideoFrames });
     this.#progress.addPhase({
       name: "Video Encode",
       total: this.#totalVideoFrames,
       getCompleted: () => this.#videoEncodeCount - this.#videoEncoder.encodeQueueSize,
-      deferTimer: true,
     });
 
     const onError = (error: unknown) => this.#abort.abort(error);
@@ -96,7 +94,7 @@ export class MediaCompositor {
     return this.#serializedAudio.duration;
   }
   get #totalVideoFrames() {
-    return this.#duration * this.#fps;
+    return Math.ceil(this.#duration * this.#fps);
   }
   get #totalAudioFrames() {
     return Math.ceil((this.#duration * 1000) / frameSize);
@@ -107,9 +105,6 @@ export class MediaCompositor {
     this.#renderAudio();
     await this.#renderVideo();
 
-    // Start encode timers now that render loops are done and flush begins
-    this.#progress.startTimer("Audio Encode");
-    this.#progress.startTimer("Video Encode");
     await Promise.all([this.#videoEncoder.flush(), this.#audioEncoder.flush()]);
     await this.#muxer.finalize();
   }

--- a/src/lib/media-compositor/media-compositor.ts
+++ b/src/lib/media-compositor/media-compositor.ts
@@ -163,7 +163,7 @@ export class MediaCompositor {
     const precomputedFFT = this.#precomputeFFT();
 
     for (let i = 0; i < this.#totalVideoFrames; i++) {
-      const currentTime = (i / this.#totalVideoFrames) * this.#duration;
+      const currentTime = i / this.#fps;
 
       backgroundRenderer.render();
 

--- a/tests/lib/media-compositor/export-progress-tracker.test.ts
+++ b/tests/lib/media-compositor/export-progress-tracker.test.ts
@@ -85,27 +85,41 @@ test("getCompleted overrides internal count", () => {
   expect(onProgress).toHaveBeenCalledWith(0.5, expect.objectContaining({ name: "encode" }));
 });
 
-test("deferTimer prevents auto-start until startTimer is called", () => {
-  const { onProgress, tracker } = setup();
-  tracker.addPhase({ name: "mux", total: 10, deferTimer: true });
+test("getCompleted phase auto-starts its timer when progress is first observed", () => {
+  const { onProgress } = setup();
+  let externalCount = 0;
+  const tracker = new ExportProgressTracker(onProgress);
+  tracker.addPhase({ name: "encode", total: 10, getCompleted: () => externalCount });
 
-  tracker.set("mux", 5);
+  externalCount = 1;
+  tracker.notify();
   flush();
 
-  // ETA should be "--" because timer was not started
-  expect(onProgress).toHaveBeenCalledWith(0.5, expect.objectContaining({ name: "mux", eta: "--" }));
-
-  onProgress.mockClear();
-
-  // Now start timer and advance
-  tracker.startTimer("mux");
   vi.advanceTimersByTime(2000);
-  tracker.set("mux", 8);
+  externalCount = 5;
+  tracker.notify();
   flush();
 
-  // ETA should be computed now (not "--")
+  // Timer started at first observation (count 1); 4 units in 2.5s → 5 remaining ≈ 3.1s
   const call = onProgress.mock.calls.at(-1);
-  expect(call?.[1]?.eta).not.toBe("--");
+  expect(call?.[1]?.eta).toBe("0m03s");
+});
+
+test("eta stays -- until progress advances past the first observation", () => {
+  const { onProgress } = setup();
+  let externalCount = 0;
+  const tracker = new ExportProgressTracker(onProgress);
+  tracker.addPhase({ name: "encode", total: 10, getCompleted: () => externalCount });
+
+  externalCount = 3;
+  tracker.notify();
+  flush();
+
+  // No progress observed since the timer started, so rate is unknown
+  expect(onProgress).toHaveBeenCalledWith(
+    0.3,
+    expect.objectContaining({ name: "encode", eta: "--" }),
+  );
 });
 
 test("eta format is NmSSs", () => {


### PR DESCRIPTION
## Summary

Fixes the export ETA display being stuck on "Video Encode — --" for most of the export, then briefly showing a near-zero value during flush.

## Root cause

Encode phases progress concurrently with their render phases (the encoder drains its queue in the background, bounded by backpressure), but their timers were deferred (`deferTimer`) and only started once both render loops finished. Meanwhile the header shows the **last** active phase — which, during video rendering, is always "Video Encode" since it is active concurrently. Result:

- During rendering (most of the export): "Video Encode — --" (timer not started)
- During flush: a bogus tiny ETA (timer just started while the phase was already ~90% complete, so the linear extrapolation collapses)

## Fix

- A phase's timer now auto-starts when its progress is first observed (works for `getCompleted`-driven phases updated via dequeue events), and ETA is computed from the completion rate **since that baseline** rather than assuming the phase started at zero. The `deferTimer` / `startTimer` mechanism is removed.
- Showing the last active phase is kept: because encode is coupled to render by backpressure, its ETA now effectively reports the remaining time of the whole render+encode stage, which is the number users actually want.
- `#totalVideoFrames` is now `Math.ceil`'d so per-phase counts can no longer exceed the total (duration × fps is fractional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)