### PR TITLE
ci: group codeql-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,4 +40,4 @@ updates:
     groups:
       codeql:
         patterns:
-          - "github/codeql-action*"
+          - "github/codeql-action/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Summary

- Add a `codeql` group to the `github-actions` ecosystem in `dependabot.yml` so `github/codeql-action/init` and `github/codeql-action/analyze` are bumped together in a single PR.

Currently #531 and #532 bump `analyze` and `init` separately, leaving the two actions at mismatched versions within each PR, which makes CodeQL CI fail. Once this is merged, Dependabot will supersede those PRs with a single grouped update on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PiTkWyigrcLWJpcAWpMke