### PR TITLE
feat: drop minutes and zero-padding from sub-minute ETA display

### DIFF
--- a/src/components/app/app-header.tsx
+++ b/src/components/app/app-header.tsx
@@ -28,7 +28,7 @@ export function AppHeader({ className, recordingState, toggleRecording }: Props)
         </div>
         <div className="flex items-center gap-2 md:ml-auto">
           {recordingState.type === "recording" && recordingState.activePhase && (
-            <span className="hidden text-muted-foreground md:inline md:text-xs">
+            <span className="hidden text-muted-foreground tabular-nums md:inline md:text-xs">
               {recordingState.activePhase.name} — {recordingState.activePhase.eta}
             </span>
           )}

--- a/src/lib/media-compositor/export-progress-tracker.ts
+++ b/src/lib/media-compositor/export-progress-tracker.ts
@@ -120,8 +120,11 @@ export class ExportProgressTracker<T extends string> {
     const progressed = done - timer.baseline;
     if (progressed <= 0 || elapsed <= 0) return "--";
     const eta = (total - done) / (progressed / elapsed);
-    const min = Math.floor(eta / 60);
-    const sec = Math.floor(eta % 60);
+    // Ceil so the countdown never shows 0s while work remains
+    const totalSec = Math.ceil(eta);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    if (min === 0) return `${sec}s`;
     return `${min}m${sec.toString().padStart(2, "0")}s`;
   }
 }

--- a/tests/lib/media-compositor/export-progress-tracker.test.ts
+++ b/tests/lib/media-compositor/export-progress-tracker.test.ts
@@ -100,9 +100,9 @@ test("getCompleted phase auto-starts its timer when progress is first observed",
   tracker.notify();
   flush();
 
-  // Timer started at first observation (count 1); 4 units in 2.5s → 5 remaining ≈ 3.1s
+  // Timer started at first observation (count 1); 4 units in 2.5s → 5 remaining ≈ 3.1s → ceil 4
   const call = onProgress.mock.calls.at(-1);
-  expect(call?.[1]?.eta).toBe("0m03s");
+  expect(call?.[1]?.eta).toBe("4s");
 });
 
 test("eta stays -- until progress advances past the first observation", () => {
@@ -122,7 +122,7 @@ test("eta stays -- until progress advances past the first observation", () => {
   );
 });
 
-test("eta format is NmSSs", () => {
+test("eta of a minute or more is NmSSs with zero-padded seconds", () => {
   const { onProgress, tracker } = setup();
   tracker.addPhase({ name: "render", total: 100 });
 
@@ -134,6 +134,62 @@ test("eta format is NmSSs", () => {
 
   const call = onProgress.mock.calls.at(-1);
   expect(call?.[1]?.eta).toBe("8m10s");
+});
+
+test("eta under a minute drops the minutes part", () => {
+  const { onProgress, tracker } = setup();
+  tracker.addPhase({ name: "render", total: 10 });
+
+  tracker.increment("render");
+  // 10s elapsed with 2/10 done → 8 remaining at 0.2/s → 40s
+  vi.advanceTimersByTime(10_000);
+  tracker.increment("render");
+  flush();
+
+  const call = onProgress.mock.calls.at(-1);
+  expect(call?.[1]?.eta).toBe("40s");
+});
+
+test("standalone seconds are not zero-padded", () => {
+  const { onProgress, tracker } = setup();
+  tracker.addPhase({ name: "render", total: 10 });
+
+  tracker.increment("render");
+  // 3s elapsed with 7/10 done → 3 remaining at 7/3 per s ≈ 1.3s → ceil 2
+  vi.advanceTimersByTime(3000);
+  tracker.set("render", 7);
+  flush();
+
+  const call = onProgress.mock.calls.at(-1);
+  expect(call?.[1]?.eta).toBe("2s");
+});
+
+test("eta never shows 0s while work remains", () => {
+  const { onProgress, tracker } = setup();
+  tracker.addPhase({ name: "render", total: 10 });
+
+  tracker.increment("render");
+  // 1s elapsed with 9/10 done → 1 remaining at 9/s ≈ 0.11s → ceil 1
+  vi.advanceTimersByTime(1000);
+  tracker.set("render", 9);
+  flush();
+
+  const call = onProgress.mock.calls.at(-1);
+  expect(call?.[1]?.eta).toBe("1s");
+});
+
+test("eta that rounds up to a full minute carries into minutes", () => {
+  const { onProgress, tracker } = setup();
+  tracker.addPhase({ name: "render", total: 10 });
+
+  tracker.increment("render");
+  // 14.875s elapsed with 2/10 done → 8 remaining → 59.5s → ceil 60 → 1m00s
+  vi.advanceTimersByTime(14_875);
+  tracker.increment("render");
+  flush();
+
+  const call = onProgress.mock.calls.at(-1);
+  expect(call?.[1]?.eta).toBe("1m00s");
 });
 
 test("activePhase is undefined when no phase is in progress", () => {


### PR DESCRIPTION
## Summary

Refines the export ETA display format:

- ETA of a minute or more keeps the current `NmSSs` format (e.g. `8m10s`)
- ETA under a minute drops the minutes part and the zero-padding, since padding only exists to align seconds against the minutes part (`0m05s` → `5s`)
- Remaining seconds are now rounded up with `Math.ceil`, so the countdown never shows `0s` while work remains and `59.5s` correctly carries into `1m00s`
- Added `tabular-nums` to the header ETA text to avoid digit jitter during countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiJnnnyg3QFHqQhoafnwkE