### PR TITLE
ci: replace pnpm/action-setup + setup-node with pnpm/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          run_install: false
-
-      - name: Set up Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+          runtime: node@24
+          cache: true
 
       - name: Get Playwright version
         id: playwright-version


### PR DESCRIPTION
## Summary

Replace the three setup steps (`pnpm/action-setup`, `actions/setup-node`, `pnpm install`) with a single [`pnpm/setup`](https://github.com/pnpm/setup) step.

`pnpm/setup` is the successor of `pnpm/action-setup` for pnpm v11+ (this repo uses `pnpm@11.24.0`). In one step it:

- installs pnpm, resolving the version from the `packageManager` field in `package.json`
- installs the Node.js runtime (`runtime: node@24`, matching the previous `node-version: 24`), replacing `actions/setup-node`
- restores/saves the pnpm store cache (`cache: true`, equivalent to setup-node's `cache: pnpm`)
- runs `pnpm install` automatically

Pinned to the v2.1.0 commit SHA, consistent with the other actions in this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CC96iNZBFh5RF5tZamG5z