### PR TITLE
fix: sync ColorPickerInput text field with external value changes

### DIFF
--- a/src/components/common/color-picker-input.tsx
+++ b/src/components/common/color-picker-input.tsx
@@ -44,6 +44,12 @@ export function ColorPickerInput({
   const colorPickerId = `${textInputId}-color-picker`;
 
   const [inputValue, setInputValue] = useState(value);
+  // Follow external value changes without a stale-frame render (no useEffect)
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setInputValue(value);
+  }
 
   const handleNativePickerChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/tests/components/common/color-picker-input.test.tsx
+++ b/tests/components/common/color-picker-input.test.tsx
@@ -192,3 +192,26 @@ test("should disable both inputs when disabled prop is true", () => {
   expect(textInput).toBeDisabled();
   expect(nativePicker).toBeDisabled();
 });
+
+// External value sync tests
+test("should update text input when value prop changes", () => {
+  const { rerender } = renderColorPickerInput({ value: "#ff0000" });
+  rerender(<ColorPickerInput value="#00ff00" onChange={mockOnChange} aria-label="Color picker" />);
+  expect(screen.getByRole("textbox")).toHaveValue("#00ff00");
+});
+
+test("should keep partial input when rerendered with the same value", () => {
+  const { rerender } = renderColorPickerInput({ value: "#ff0000" });
+  const input = screen.getByRole("textbox");
+  fireEvent.change(input, { target: { value: "#00f" } });
+  rerender(<ColorPickerInput value="#ff0000" onChange={mockOnChange} aria-label="Color picker" />);
+  expect(input).toHaveValue("#00f");
+});
+
+test("should replace partial input when value prop changes", () => {
+  const { rerender } = renderColorPickerInput({ value: "#ff0000" });
+  const input = screen.getByRole("textbox");
+  fireEvent.change(input, { target: { value: "#00f" } });
+  rerender(<ColorPickerInput value="#0000ff" onChange={mockOnChange} aria-label="Color picker" />);
+  expect(input).toHaveValue("#0000ff");
+});


### PR DESCRIPTION
## Summary

- `ColorPickerInput` kept the hex text field in local state that was initialised only once, so external `value` changes (the "Color preset" menu in the track list pane, the hue randomize dialog, renderer config reset/merge) updated the native colour input and the swatch but left the text field showing the stale hex string.
- The component now tracks the last seen `value` prop and resets the text field when it changes, using React's "adjust state when a prop changes" pattern instead of `useEffect`, so there is no one-frame stale render.
- A rerender with the same `value` still leaves an in-progress (partial or invalid) text entry untouched.

## Tests

Added to `tests/components/common/color-picker-input.test.tsx`:

- text input follows a `value` prop change
- partial input is kept when rerendered with the same `value`
- partial input is replaced when the `value` prop changes

Verified with `pnpm test --project unit tests/components/common/color-picker-input.test.tsx`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and `pnpm knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)