### PR TITLE
refactor: use @/ alias for parent-relative imports

### DIFF
--- a/src/components/app/about-content.tsx
+++ b/src/components/app/about-content.tsx
@@ -1,10 +1,9 @@
 import { CircleCheck, CircleX, Info } from "lucide-react";
 import { useMemo } from "react";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { checkBrowserApis } from "@/lib/browser-compat/browser-compat";
 import { cn } from "@/lib/utils";
-
-import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 
 interface Props {
   className?: string;

--- a/src/components/app/keyboard-shortcuts-content.tsx
+++ b/src/components/app/keyboard-shortcuts-content.tsx
@@ -1,4 +1,4 @@
-import { Kbd } from "../ui/kbd";
+import { Kbd } from "@/components/ui/kbd";
 
 interface ShortcutItem {
   key: string;

--- a/src/components/common/info-tooltip.tsx
+++ b/src/components/common/info-tooltip.tsx
@@ -1,6 +1,6 @@
 import { Info } from "lucide-react";
 
-import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 export function InfoTooltip({ children }: { children: React.ReactNode }) {
   return (

--- a/src/components/providers/providers.tsx
+++ b/src/components/providers/providers.tsx
@@ -2,10 +2,10 @@ import { Suspense, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { AudioContext } from "standardized-audio-context";
 
+import { AppContext, createAppContext } from "@/contexts/app-context";
 import { PwaContext } from "@/contexts/pwa-context";
 import { usePwaState } from "@/lib/pwa/use-pwa-state";
 
-import { AppContext, createAppContext } from "../../contexts/app-context";
 import { Fallback } from "./fallback";
 import { FileDbStoreProvider } from "./file-db-store-provider";
 import { Loading } from "./loading";

--- a/src/lib/file-db/file-db-store.ts
+++ b/src/lib/file-db/file-db-store.ts
@@ -1,9 +1,8 @@
 import { createContext, use, useSyncExternalStore } from "react";
 
+import { type StoredAudioData } from "@/lib/audio/audio";
 import { errorLogWithToast } from "@/lib/error-toast";
 import { fetchValue, saveValue } from "@/lib/file-db/file-db";
-
-import { type StoredAudioData } from "../audio/audio";
 
 export interface FileDbEntry<T = unknown> {
   file: File;

--- a/src/lib/media-compositor/recorder-resources.ts
+++ b/src/lib/media-compositor/recorder-resources.ts
@@ -1,6 +1,6 @@
-import { AudioSource } from "../audio/audio";
-import { MidiTracks } from "../midi/midi";
-import { RendererConfig } from "../renderers/renderer";
+import { AudioSource } from "@/lib/audio/audio";
+import { MidiTracks } from "@/lib/midi/midi";
+import { RendererConfig } from "@/lib/renderers/renderer";
 
 export interface RecorderResources {
   readonly midiTracks?: MidiTracks;

--- a/src/lib/muxer/muxer.ts
+++ b/src/lib/muxer/muxer.ts
@@ -14,7 +14,7 @@ import {
   AudioCodec,
 } from "mediabunny";
 
-import { VideoFormat } from "../renderers/renderer";
+import { VideoFormat } from "@/lib/renderers/renderer";
 
 interface Config {
   outputFormat: OutputFormat;

--- a/src/lib/renderers/comet/comet-renderer.ts
+++ b/src/lib/renderers/comet/comet-renderer.ts
@@ -1,6 +1,5 @@
 import { MidiTrack } from "@/lib/midi/midi";
-
-import { Renderer, RendererConfig } from "../renderer";
+import { Renderer, RendererConfig } from "@/lib/renderers/renderer";
 
 interface CometParticle {
   x: number;

--- a/tests/components/app/footer-panel.test.tsx
+++ b/tests/components/app/footer-panel.test.tsx
@@ -1,12 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ComponentProps } from "react";
+import { createMockPwaState } from "tests/pwa-mock";
 import { expect, test, vi } from "vitest";
 
 import { FooterPanel } from "@/components/app/footer-panel";
 import { PwaContext, PwaState } from "@/contexts/pwa-context";
-
-import { createMockPwaState } from "../../pwa-mock";
 
 type Props = ComponentProps<typeof FooterPanel>;
 

--- a/tests/components/app/mobile-bottom-nav.test.tsx
+++ b/tests/components/app/mobile-bottom-nav.test.tsx
@@ -1,12 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ComponentProps } from "react";
+import { createMockPwaState } from "tests/pwa-mock";
 import { expect, test, vi } from "vitest";
 
 import { MobileBottomNav } from "@/components/app/mobile-bottom-nav";
 import { PwaContext, PwaState } from "@/contexts/pwa-context";
-
-import { createMockPwaState } from "../../pwa-mock";
 
 type Props = ComponentProps<typeof MobileBottomNav>;
 

--- a/tests/lib/audio/use-audio.test.tsx
+++ b/tests/lib/audio/use-audio.test.tsx
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import { AudioContext } from "standardized-audio-context-mock";
+import { audioFile, invalidFile } from "tests/fixtures";
 import { customRenderHook } from "tests/util";
 import { test, expect, vi } from "vitest";
 
@@ -10,8 +11,6 @@ import { runDecodeWorker } from "@/lib/audio/run-decode-worker";
 import { useAudio } from "@/lib/audio/use-audio";
 import { saveValue } from "@/lib/file-db/file-db";
 import type { FileDbEntry } from "@/lib/file-db/file-db-store";
-
-import { audioFile, invalidFile } from "../../fixtures";
 
 vi.mock("@/lib/audio/run-decode-worker", { spy: true });
 

--- a/tests/main.test.tsx
+++ b/tests/main.test.tsx
@@ -5,7 +5,7 @@ test("should render the app", { timeout: 10000 }, async () => {
   const container = document.createElement("div");
   container.id = "root";
   document.body.appendChild(container);
-  await import("../src/main");
+  await import("@/main");
   const app = await screen.findByText("MiVi");
   expect(app).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary

- Replace every `../` (parent-relative) import under `src/` with the `@/` alias, resolving each path relative to the importing file (e.g. `../renderer` in `src/lib/renderers/comet/comet-renderer.ts` becomes `@/lib/renderers/renderer`).
- In `tests/`, convert the import that pointed into `src/` (`tests/main.test.tsx`: `import("../src/main")` → `import("@/main")`), and rewrite the remaining `../../pwa-mock` / `../../fixtures` imports to the root-based `tests/pwa-mock` / `tests/fixtures` form already used by the other tests.
- Same-directory `./` imports are untouched. No behaviour changes; `oxlint --fix` regrouped a few import blocks as a result of the path change.

`src/lib/renderers/renderer.ts` already used the alias on `main`, so it needed no change. After this PR, `grep -rnE '["'"'"']\.\./' src tests` returns nothing.

## Test plan

- [x] `pnpm oxlint --fix src tests`
- [x] `pnpm format`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm knip`
- [x] `pnpm test --project unit` (66 files, 703 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)