### PR TITLE
fix: mount style tab panels only while active so slider thumbs get positioned

### DIFF
--- a/src/components/app/visualizer-style-pane.tsx
+++ b/src/components/app/visualizer-style-pane.tsx
@@ -93,7 +93,7 @@ export function VisualizerStylePane() {
         <TabsTrigger value="audio">Audio Style</TabsTrigger>
         <TabsIndicator />
       </TabsList>
-      <TabsContent keepMounted value="visualizer" className="overflow-hidden">
+      <TabsContent value="visualizer" className="overflow-hidden">
         <ScrollArea className="h-full" orientation="vertical">
           <Card variant="transparent">
             <CardContent className="space-y-4">
@@ -131,7 +131,7 @@ export function VisualizerStylePane() {
           </Card>
         </ScrollArea>
       </TabsContent>
-      <TabsContent value="audio" className="overflow-hidden" keepMounted>
+      <TabsContent value="audio" className="overflow-hidden">
         <ScrollArea className="h-full" orientation="vertical">
           <Card variant="transparent">
             <CardContent className="space-y-4">

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -19,6 +19,26 @@ function isArray(v: SliderPrimitive.Root.Props["value"]): v is readonly number[]
   return Array.isArray(v);
 }
 
+/**
+ * Base UI measures inset thumbs once after mount and never re-measures on its own, so a slider
+ * that mounts inside a hidden container keeps an unpositioned thumb. Remount it when it appears.
+ */
+function useRemountWhenShown() {
+  const [mountKey, setMountKey] = React.useState(0);
+  const controlRef = React.useCallback((control: HTMLElement | null) => {
+    if (!control || typeof ResizeObserver === "undefined") return;
+    if (control.getClientRects().length > 0) return;
+    const observer = new ResizeObserver(() => {
+      if (control.getClientRects().length === 0) return;
+      observer.disconnect();
+      setMountKey((key) => key + 1);
+    });
+    observer.observe(control);
+    return () => observer.disconnect();
+  }, []);
+  return { mountKey, controlRef };
+}
+
 function roundToStep(value: number, step: number): number {
   const precision = Math.max(0, -Math.floor(Math.log10(step)));
   const factor = 10 ** precision;
@@ -41,8 +61,10 @@ function Slider({
   );
 
   const step = props.step ?? 1;
+  const { mountKey, controlRef } = useRemountWhenShown();
   return (
     <SliderPrimitive.Root
+      key={mountKey}
       className={cn("group data-horizontal:w-full data-vertical:h-full", className)}
       data-slot="slider"
       defaultValue={defaultValue}
@@ -64,7 +86,10 @@ function Slider({
       }}
       {...props}
     >
-      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-horizontal:min-h-5 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+      <SliderPrimitive.Control
+        ref={controlRef}
+        className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-horizontal:min-h-5 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col"
+      >
         <SliderPrimitive.Track
           data-slot="slider-track"
           className="relative grow overflow-hidden rounded-full bg-muted select-none group-hover:bg-foreground/5 data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1.5"

--- a/tests/components/ui/slider.browser.tsx
+++ b/tests/components/ui/slider.browser.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { page } from "vitest/browser";
+
+import { Slider } from "@/components/ui/slider";
+
+import "@/index.css";
+
+function thumbState() {
+  const thumb = document.querySelector<HTMLElement>('[data-slot="slider-thumb"]')!;
+  const control = thumb.parentElement!;
+  const c = control.getBoundingClientRect();
+  const t = thumb.getBoundingClientRect();
+  const expected = c.left + t.width / 2 + (c.width - t.width) * 0.5;
+  return {
+    visibility: getComputedStyle(thumb).visibility,
+    offset: Math.round(t.left + t.width / 2 - expected),
+  };
+}
+
+test("a slider mounted inside a hidden container positions its thumb once shown", async () => {
+  await page.render(
+    <div hidden data-testid="container" style={{ width: 200 }}>
+      <Slider value={[50]} min={0} max={100} aria-label="volume" />
+    </div>,
+  );
+  expect(thumbState().visibility).toBe("hidden");
+
+  document.querySelector<HTMLElement>('[data-testid="container"]')!.hidden = false;
+
+  await expect.poll(thumbState).toEqual({ visibility: "visible", offset: 0 });
+});


### PR DESCRIPTION
## Summary

- `Slider` now remounts itself when it was mounted inside a hidden container and later becomes visible. A `ResizeObserver` is attached to the control only while it has no box, so sliders that mount visibly are untouched.
- Drop `keepMounted` from the two `TabsContent` panels in `VisualizerStylePane`, so each style panel mounts when it becomes visible.
- Browser test covering a slider mounted under `hidden` and then shown.

## Root cause

`Slider` uses `thumbAlignment="edge-client-only"`. Base UI computes the inset thumb position with `getBoundingClientRect()` from a microtask after mount and thereafter only via a `ResizeObserver`. That observer is set up in the thumb's layout effect, which runs before the parent `Slider.Control` ref is attached, so on first mount `controlRef.current` is still `null` and the observer is never created. A thumb mounted inside a `display: none` container therefore measures `NaN`, renders with `visibility: hidden`, and nothing re-measures it when the container is shown.

This affects every place a slider mounts hidden: the inactive style tab (with `keepMounted`), and on mobile the Style and Tracks panels, which `App` keeps mounted under `hidden` until their tab is selected. Handling it in the `Slider` wrapper covers all of them.

Verified with Playwright against `vite preview`: desktop tab switch (8/8 thumbs previously hidden) and mobile Style / Tracks tabs (19 and 4 thumbs) all render positioned thumbs now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
