### PR TITLE
feat: add portrait presets and a custom size to the resolution select

### DIFF
--- a/src/components/app/common-config-pane.tsx
+++ b/src/components/app/common-config-pane.tsx
@@ -75,6 +75,12 @@ export const CommonConfigPane = memo(function CommonConfigPane() {
   const { backgroundImageFile, setBackgroundImageFile } = useBackgroundImage();
   const backgroundImageFilename = backgroundImageFile?.name;
   const customWidthInputRef = useRef<HTMLInputElement>(null);
+  const focusCustomOnCloseRef = useRef(false);
+  const focusAfterResolutionClose = () => {
+    if (!focusCustomOnCloseRef.current) return true;
+    focusCustomOnCloseRef.current = false;
+    return customWidthInputRef.current ?? true;
+  };
   return (
     <Card variant="transparent">
       <CardHeader>
@@ -247,13 +253,14 @@ export const CommonConfigPane = memo(function CommonConfigPane() {
                 const resolution =
                   customResolution ?? createCustomResolution(current.width, current.height);
                 onUpdateRendererConfig({ resolution, customResolution: resolution });
+                focusCustomOnCloseRef.current = true;
               }}
               items={resolutionItems}
             >
               <SelectTrigger id={id} className="w-48">
                 <SelectValue placeholder="Select resolution" />
               </SelectTrigger>
-              <SelectContent finalFocus={() => customWidthInputRef.current ?? true}>
+              <SelectContent finalFocus={focusAfterResolutionClose}>
                 {resolutionGroups.map((group) => (
                   <SelectGroup key={group.label}>
                     <SelectLabel>{group.label}</SelectLabel>

--- a/src/components/app/common-config-pane.tsx
+++ b/src/components/app/common-config-pane.tsx
@@ -1,5 +1,6 @@
-import { memo } from "react";
+import { memo, useRef } from "react";
 
+import { CustomResolutionFields } from "@/components/app/custom-resolution-fields";
 import { ColorPickerInput } from "@/components/common/color-picker-input";
 import { FileButton } from "@/components/common/file-button";
 import { FormRow } from "@/components/common/form-row";
@@ -9,13 +10,20 @@ import {
   SelectTrigger,
   SelectValue,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { useAudio } from "@/lib/audio/use-audio";
 import { useBackgroundImage } from "@/lib/background-image/use-background-image";
 import {
+  createCustomResolution,
+  CUSTOM_RESOLUTION_LABEL,
+  isCustomResolution,
+  resolutionGroups,
   resolutions,
   FPS,
   fpsOptions,
@@ -29,6 +37,11 @@ import {
 import { useRendererConfig, useUpdateRendererConfig } from "@/lib/renderers/use-renderer-config";
 import { shallowEqual } from "@/lib/store/observable-store";
 
+const resolutionItems = [...resolutions, { label: CUSTOM_RESOLUTION_LABEL }].map(({ label }) => ({
+  value: label,
+  label,
+}));
+
 const selectCommonConfig = ({
   backgroundColor,
   backgroundImageEnabled,
@@ -37,6 +50,7 @@ const selectCommonConfig = ({
   backgroundImageRepeat,
   backgroundImageOpacity,
   resolution,
+  customResolution,
   fps,
   format,
   audioVisualizerLayer,
@@ -48,6 +62,7 @@ const selectCommonConfig = ({
   backgroundImageRepeat,
   backgroundImageOpacity,
   resolution,
+  customResolution,
   fps,
   format,
   audioVisualizerLayer,
@@ -59,6 +74,7 @@ export const CommonConfigPane = memo(function CommonConfigPane() {
   const { audioFile, setAudioFile, isDecoding, cancelDecode } = useAudio();
   const { backgroundImageFile, setBackgroundImageFile } = useBackgroundImage();
   const backgroundImageFilename = backgroundImageFile?.name;
+  const customWidthInputRef = useRef<HTMLInputElement>(null);
   return (
     <Card variant="transparent">
       <CardHeader>
@@ -221,27 +237,56 @@ export const CommonConfigPane = memo(function CommonConfigPane() {
               value={rendererConfig.resolution.label}
               onValueChange={(value) => {
                 if (value == null) return;
-                const resolution = resolutions.find((r) => r.label === value);
-                onUpdateRendererConfig({ resolution });
+                if (value !== CUSTOM_RESOLUTION_LABEL) {
+                  onUpdateRendererConfig({
+                    resolution: resolutions.find((r) => r.label === value),
+                  });
+                  return;
+                }
+                const { resolution: current, customResolution } = rendererConfig;
+                const resolution =
+                  customResolution ?? createCustomResolution(current.width, current.height);
+                onUpdateRendererConfig({ resolution, customResolution: resolution });
               }}
-              items={resolutions.map((r) => ({
-                value: r.label,
-                label: r.label,
-              }))}
+              items={resolutionItems}
             >
               <SelectTrigger id={id} className="w-48">
                 <SelectValue placeholder="Select resolution" />
               </SelectTrigger>
-              <SelectContent>
-                {resolutions.map((resolution) => (
-                  <SelectItem key={resolution.label} value={resolution.label}>
-                    {resolution.label}
-                  </SelectItem>
+              <SelectContent finalFocus={() => customWidthInputRef.current ?? true}>
+                {resolutionGroups.map((group) => (
+                  <SelectGroup key={group.label}>
+                    <SelectLabel>{group.label}</SelectLabel>
+                    {group.resolutions.map((resolution) => (
+                      <SelectItem key={resolution.label} value={resolution.label}>
+                        {resolution.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 ))}
+                <SelectSeparator />
+                <SelectGroup>
+                  <SelectItem value={CUSTOM_RESOLUTION_LABEL}>{CUSTOM_RESOLUTION_LABEL}</SelectItem>
+                </SelectGroup>
               </SelectContent>
             </Select>
           )}
         />
+        {isCustomResolution(rendererConfig.resolution) && (
+          <FormRow
+            label={<span>Custom Size</span>}
+            customControl
+            controller={() => (
+              <CustomResolutionFields
+                widthInputRef={customWidthInputRef}
+                resolution={rendererConfig.resolution}
+                onChange={(resolution) =>
+                  onUpdateRendererConfig({ resolution, customResolution: resolution })
+                }
+              />
+            )}
+          />
+        )}
         <FormRow
           label={<span>FPS</span>}
           controller={({ id }) => (

--- a/src/components/app/custom-resolution-fields.tsx
+++ b/src/components/app/custom-resolution-fields.tsx
@@ -24,7 +24,7 @@ function SizeInput({ ref, label, value, onCommit }: SizeInputProps) {
   }
 
   const commit = useCallback(() => {
-    const parsed = Number.parseInt(draft, 10);
+    const parsed = draft.trim() === "" ? Number.NaN : Number(draft);
     const committed = Number.isNaN(parsed) ? value : onCommit(parsed);
     setDraft(String(committed));
   }, [draft, onCommit, value]);

--- a/src/components/app/custom-resolution-fields.tsx
+++ b/src/components/app/custom-resolution-fields.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  createCustomResolution,
+  MAX_RESOLUTION_SIZE,
+  MIN_RESOLUTION_SIZE,
+  Resolution,
+} from "@/lib/renderers/renderer";
+
+interface SizeInputProps {
+  ref?: React.Ref<HTMLInputElement>;
+  label: string;
+  value: number;
+  onCommit: (value: number) => number;
+}
+
+function SizeInput({ ref, label, value, onCommit }: SizeInputProps) {
+  const [draft, setDraft] = useState(String(value));
+  const [syncedValue, setSyncedValue] = useState(value);
+  if (syncedValue !== value) {
+    setSyncedValue(value);
+    setDraft(String(value));
+  }
+
+  const commit = useCallback(() => {
+    const parsed = Number.parseInt(draft, 10);
+    const committed = Number.isNaN(parsed) ? value : onCommit(parsed);
+    setDraft(String(committed));
+  }, [draft, onCommit, value]);
+
+  return (
+    <Input
+      ref={ref}
+      type="number"
+      inputMode="numeric"
+      aria-label={label}
+      min={MIN_RESOLUTION_SIZE}
+      max={MAX_RESOLUTION_SIZE}
+      step={2}
+      className="w-20 text-right"
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") commit();
+      }}
+    />
+  );
+}
+
+interface Props {
+  widthInputRef?: React.Ref<HTMLInputElement>;
+  resolution: Resolution;
+  onChange: (resolution: Resolution) => void;
+}
+
+export function CustomResolutionFields({ widthInputRef, resolution, onChange }: Props) {
+  const commitWidth = useCallback(
+    (width: number) => {
+      const next = createCustomResolution(width, resolution.height, "width");
+      onChange(next);
+      return next.width;
+    },
+    [onChange, resolution.height],
+  );
+  const commitHeight = useCallback(
+    (height: number) => {
+      const next = createCustomResolution(resolution.width, height, "height");
+      onChange(next);
+      return next.height;
+    },
+    [onChange, resolution.width],
+  );
+  return (
+    <div className="flex items-center gap-1.5">
+      <SizeInput
+        ref={widthInputRef}
+        label="Width"
+        value={resolution.width}
+        onCommit={commitWidth}
+      />
+      <span className="text-muted-foreground">×</span>
+      <SizeInput label="Height" value={resolution.height} onCommit={commitHeight} />
+    </div>
+  );
+}

--- a/src/lib/media-compositor/media-compositor.ts
+++ b/src/lib/media-compositor/media-compositor.ts
@@ -67,7 +67,7 @@ export class MediaCompositor {
       this.#rendererConfig.resolution.height,
     );
     this.#videoEncoder.configure({
-      codec: muxer.config.videoCodec,
+      codec: muxer.config.videoCodec(this.#rendererConfig.resolution),
       width: this.#canvas.width,
       height: this.#canvas.height,
       bitrate: 10_000_000,

--- a/src/lib/media-compositor/media-compositor.ts
+++ b/src/lib/media-compositor/media-compositor.ts
@@ -67,7 +67,7 @@ export class MediaCompositor {
       this.#rendererConfig.resolution.height,
     );
     this.#videoEncoder.configure({
-      codec: muxer.config.videoCodec(this.#rendererConfig.resolution),
+      codec: muxer.config.videoCodec(this.#rendererConfig.resolution, this.#fps),
       width: this.#canvas.width,
       height: this.#canvas.height,
       bitrate: 10_000_000,

--- a/src/lib/muxer/h264-level.ts
+++ b/src/lib/muxer/h264-level.ts
@@ -3,23 +3,34 @@ interface FrameSize {
   height: number;
 }
 
-const H264_LEVELS: { hex: string; maxMacroblocks: number }[] = [
-  { hex: "29", maxMacroblocks: 8192 },
-  { hex: "2A", maxMacroblocks: 8704 },
-  { hex: "32", maxMacroblocks: 22080 },
-  { hex: "33", maxMacroblocks: 36864 },
+const H264_LEVELS: { hex: string; maxMacroblocks: number; maxMacroblocksPerSecond: number }[] = [
+  { hex: "29", maxMacroblocks: 8192, maxMacroblocksPerSecond: 245_760 },
+  { hex: "2A", maxMacroblocks: 8704, maxMacroblocksPerSecond: 522_240 },
+  { hex: "32", maxMacroblocks: 22080, maxMacroblocksPerSecond: 589_824 },
+  { hex: "33", maxMacroblocks: 36864, maxMacroblocksPerSecond: 983_040 },
+  { hex: "34", maxMacroblocks: 36864, maxMacroblocksPerSecond: 2_073_600 },
+  { hex: "3C", maxMacroblocks: 139264, maxMacroblocksPerSecond: 4_177_920 },
 ];
 
-export const H264_MAX_MACROBLOCKS = H264_LEVELS[H264_LEVELS.length - 1].maxMacroblocks;
+// Chromium's H.264 encoder rejects larger frames whatever level is declared
+export const H264_MAX_MACROBLOCKS = 36864;
 
 export const countMacroblocks = ({ width, height }: FrameSize): number =>
   Math.ceil(width / 16) * Math.ceil(height / 16);
 
-export function getH264CodecString(frameSize: FrameSize): string {
+export function getH264CodecString(frameSize: FrameSize, frameRate: number): string {
   const macroblocks = countMacroblocks(frameSize);
-  const level = H264_LEVELS.find((l) => macroblocks <= l.maxMacroblocks);
+  if (macroblocks > H264_MAX_MACROBLOCKS) {
+    throw new Error(
+      `Frame size ${frameSize.width}x${frameSize.height} exceeds the H.264 encoder limit`,
+    );
+  }
+  const macroblocksPerSecond = macroblocks * frameRate;
+  const level = H264_LEVELS.find(
+    (l) => macroblocks <= l.maxMacroblocks && macroblocksPerSecond <= l.maxMacroblocksPerSecond,
+  );
   if (!level) {
-    throw new Error(`Frame size ${frameSize.width}x${frameSize.height} exceeds H.264 level 5.1`);
+    throw new Error(`${frameSize.width}x${frameSize.height}@${frameRate} exceeds H.264 level 6.0`);
   }
   return `avc1.42E0${level.hex}`;
 }

--- a/src/lib/muxer/h264-level.ts
+++ b/src/lib/muxer/h264-level.ts
@@ -1,0 +1,25 @@
+interface FrameSize {
+  width: number;
+  height: number;
+}
+
+const H264_LEVELS: { hex: string; maxMacroblocks: number }[] = [
+  { hex: "29", maxMacroblocks: 8192 },
+  { hex: "2A", maxMacroblocks: 8704 },
+  { hex: "32", maxMacroblocks: 22080 },
+  { hex: "33", maxMacroblocks: 36864 },
+];
+
+export const H264_MAX_MACROBLOCKS = H264_LEVELS[H264_LEVELS.length - 1].maxMacroblocks;
+
+export const countMacroblocks = ({ width, height }: FrameSize): number =>
+  Math.ceil(width / 16) * Math.ceil(height / 16);
+
+export function getH264CodecString(frameSize: FrameSize): string {
+  const macroblocks = countMacroblocks(frameSize);
+  const level = H264_LEVELS.find((l) => macroblocks <= l.maxMacroblocks);
+  if (!level) {
+    throw new Error(`Frame size ${frameSize.width}x${frameSize.height} exceeds H.264 level 5.1`);
+  }
+  return `avc1.42E0${level.hex}`;
+}

--- a/src/lib/muxer/muxer.ts
+++ b/src/lib/muxer/muxer.ts
@@ -14,13 +14,14 @@ import {
   AudioCodec,
 } from "mediabunny";
 
-import { VideoFormat } from "@/lib/renderers/renderer";
+import { getH264CodecString } from "@/lib/muxer/h264-level";
+import { Resolution, VideoFormat } from "@/lib/renderers/renderer";
 
 interface Config {
   outputFormat: OutputFormat;
   videoCodecId: VideoCodec;
   audioCodecId: AudioCodec;
-  videoCodec: string;
+  videoCodec: (resolution: Resolution) => string;
   audioCodec: string;
   mimeType: string;
 }
@@ -40,7 +41,7 @@ const FORMAT_CONFIGS: Record<VideoFormat, Config> = {
     outputFormat: new WebMOutputFormat(),
     videoCodecId: "vp9" as const,
     audioCodecId: "opus" as const,
-    videoCodec: "vp09.00.41.08",
+    videoCodec: () => "vp09.00.41.08",
     audioCodec: "opus",
     mimeType: "video/webm",
   },
@@ -48,7 +49,7 @@ const FORMAT_CONFIGS: Record<VideoFormat, Config> = {
     outputFormat: new Mp4OutputFormat({ fastStart: false }),
     videoCodecId: "avc" as const,
     audioCodecId: "aac" as const,
-    videoCodec: "avc1.42E029",
+    videoCodec: getH264CodecString,
     audioCodec: "mp4a.40.2",
     mimeType: "video/mp4",
   },

--- a/src/lib/muxer/muxer.ts
+++ b/src/lib/muxer/muxer.ts
@@ -21,7 +21,7 @@ interface Config {
   outputFormat: OutputFormat;
   videoCodecId: VideoCodec;
   audioCodecId: AudioCodec;
-  videoCodec: (resolution: Resolution) => string;
+  videoCodec: (resolution: Resolution, frameRate: number) => string;
   audioCodec: string;
   mimeType: string;
 }

--- a/src/lib/renderers/renderer.ts
+++ b/src/lib/renderers/renderer.ts
@@ -1,4 +1,5 @@
 import { MidiTrack } from "@/lib/midi/midi";
+import { H264_MAX_MACROBLOCKS } from "@/lib/muxer/h264-level";
 
 export interface NoteEffectsConfigValues {
   showRippleEffect: boolean;
@@ -91,15 +92,81 @@ export type Resolution = {
   label: string;
 };
 
-export const resolutions: Resolution[] = [
-  { width: 1920, height: 1080, label: "1920×1080 (16:9)" },
-  { width: 1280, height: 720, label: "1280×720 (16:9)" },
-  { width: 854, height: 480, label: "854×480 (16:9)" },
-  { width: 1440, height: 1080, label: "1440×1080 (4:3)" },
-  { width: 1024, height: 768, label: "1024×768 (4:3)" },
-  { width: 1080, height: 1080, label: "1080×1080 (1:1)" },
-  { width: 720, height: 720, label: "720×720 (1:1)" },
+export type ResolutionGroup = {
+  label: string;
+  resolutions: Resolution[];
+};
+
+export const resolutionGroups: ResolutionGroup[] = [
+  {
+    label: "Landscape",
+    resolutions: [
+      { width: 1920, height: 1080, label: "1920×1080 (16:9)" },
+      { width: 1280, height: 720, label: "1280×720 (16:9)" },
+      { width: 854, height: 480, label: "854×480 (16:9)" },
+      { width: 1440, height: 1080, label: "1440×1080 (4:3)" },
+      { width: 1024, height: 768, label: "1024×768 (4:3)" },
+    ],
+  },
+  {
+    label: "Portrait",
+    resolutions: [
+      { width: 1080, height: 1920, label: "1080×1920 (9:16)" },
+      { width: 720, height: 1280, label: "720×1280 (9:16)" },
+      { width: 480, height: 854, label: "480×854 (9:16)" },
+      { width: 1080, height: 1440, label: "1080×1440 (3:4)" },
+      { width: 768, height: 1024, label: "768×1024 (3:4)" },
+    ],
+  },
+  {
+    label: "Square",
+    resolutions: [
+      { width: 1080, height: 1080, label: "1080×1080 (1:1)" },
+      { width: 720, height: 720, label: "720×720 (1:1)" },
+    ],
+  },
 ];
+
+export const resolutions: Resolution[] = resolutionGroups.flatMap((group) => group.resolutions);
+
+export const CUSTOM_RESOLUTION_LABEL = "Custom";
+export const MIN_RESOLUTION_SIZE = 16;
+export const MAX_RESOLUTION_SIZE = 4096;
+
+export const isCustomResolution = (resolution: Resolution): boolean =>
+  resolution.label === CUSTOM_RESOLUTION_LABEL;
+
+// H.264 4:2:0 output needs even dimensions, so odd input is rounded up
+const normalizeResolutionSize = (size: number): number => {
+  if (Number.isNaN(size)) return MIN_RESOLUTION_SIZE;
+  const even = Math.ceil(size / 2) * 2;
+  return Math.min(MAX_RESOLUTION_SIZE, Math.max(MIN_RESOLUTION_SIZE, even));
+};
+
+const MACROBLOCK_SIZE = 16;
+
+// The side being edited gives way, so the other side keeps what the user already had
+const fitResolutionSize = (size: number, otherSize: number): number => {
+  const otherMacroblocks = Math.ceil(otherSize / MACROBLOCK_SIZE);
+  const maxSize = Math.floor(H264_MAX_MACROBLOCKS / otherMacroblocks) * MACROBLOCK_SIZE;
+  return Math.min(size, maxSize);
+};
+
+export const createCustomResolution = (
+  width: number,
+  height: number,
+  adjust: "width" | "height" = "width",
+): Resolution => {
+  const normalizedWidth = normalizeResolutionSize(width);
+  const normalizedHeight = normalizeResolutionSize(height);
+  return {
+    width:
+      adjust === "width" ? fitResolutionSize(normalizedWidth, normalizedHeight) : normalizedWidth,
+    height:
+      adjust === "height" ? fitResolutionSize(normalizedHeight, normalizedWidth) : normalizedHeight,
+    label: CUSTOM_RESOLUTION_LABEL,
+  };
+};
 
 export type RendererType = "none" | "pianoRoll" | "verticalPianoRoll" | "comet";
 
@@ -254,6 +321,8 @@ export interface RendererConfig {
   backgroundImageRepeat: BackgroundImageRepeat;
   backgroundImageOpacity: number;
   resolution: Resolution;
+  // Last size entered for Custom, restored when Custom is picked again
+  customResolution?: Resolution;
   fps: FPS;
   format: VideoFormat;
   pianoRollConfig: PianoRollConfigValues;

--- a/tests/components/app/common-config-pane.test.tsx
+++ b/tests/components/app/common-config-pane.test.tsx
@@ -186,3 +186,107 @@ test("should show background image toggle when image is selected", async () => {
   await renderCommonConfigPane();
   expect(screen.getByRole("switch", { name: "Show Background Image" })).toBeInTheDocument();
 });
+
+async function selectResolution(name: string) {
+  await userEvent.click(screen.getByRole("combobox", { name: "Resolution" }));
+  await userEvent.click(screen.getByRole("option", { name }));
+}
+
+test("should group resolution presets by orientation", async () => {
+  await renderCommonConfigPane();
+  await userEvent.click(screen.getByRole("combobox", { name: "Resolution" }));
+  const listbox = screen.getByRole("listbox");
+  expect(within(listbox).getByText("Landscape")).toBeInTheDocument();
+  expect(within(listbox).getByText("Portrait")).toBeInTheDocument();
+  expect(within(listbox).getByText("Square")).toBeInTheDocument();
+  expect(within(listbox).getByRole("option", { name: "1080×1920 (9:16)" })).toBeInTheDocument();
+  expect(within(listbox).getByRole("option", { name: "Custom" })).toBeInTheDocument();
+});
+
+test("should not show custom size inputs while a preset is selected", async () => {
+  await renderCommonConfigPane();
+  expect(screen.queryByRole("spinbutton", { name: "Width" })).not.toBeInTheDocument();
+});
+
+test("should seed custom size inputs with the previously selected resolution", async () => {
+  const { config } = await renderCommonConfigPane();
+  const before = config().resolution;
+  await selectResolution("Custom");
+  expect(config().resolution).toEqual({ ...before, label: "Custom" });
+  expect(screen.getByRole("spinbutton", { name: "Width" })).toHaveValue(before.width);
+  expect(screen.getByRole("spinbutton", { name: "Height" })).toHaveValue(before.height);
+});
+
+test("should move focus into the width input when Custom is picked", async () => {
+  await renderCommonConfigPane();
+  await selectResolution("Custom");
+  expect(screen.getByRole("spinbutton", { name: "Width" })).toHaveFocus();
+});
+
+test("should return focus to the trigger when a preset is picked", async () => {
+  await renderCommonConfigPane();
+  await selectResolution("Custom");
+  await selectResolution("1080×1920 (9:16)");
+  expect(screen.getByRole("combobox", { name: "Resolution" })).toHaveFocus();
+});
+
+test("should commit a normalized custom size on blur", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const width = screen.getByRole("spinbutton", { name: "Width" });
+  await userEvent.clear(width);
+  await userEvent.type(width, "1001");
+  expect(config().resolution.width).toBe(1280);
+  await userEvent.tab();
+  expect(config().resolution.width).toBe(1002);
+  expect(width).toHaveValue(1002);
+});
+
+test("should commit a custom size on Enter", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const height = screen.getByRole("spinbutton", { name: "Height" });
+  await userEvent.clear(height);
+  await userEvent.type(height, "900{Enter}");
+  expect(config().resolution.height).toBe(900);
+});
+
+test("should restore the last committed size when the input is left empty", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const width = screen.getByRole("spinbutton", { name: "Width" });
+  await userEvent.clear(width);
+  await userEvent.tab();
+  expect(config().resolution.width).toBe(1280);
+  expect(width).toHaveValue(1280);
+});
+
+test("should restore the last custom size when Custom is picked again", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const width = screen.getByRole("spinbutton", { name: "Width" });
+  await userEvent.clear(width);
+  await userEvent.type(width, "1000{Enter}");
+  await selectResolution("1080×1920 (9:16)");
+  await selectResolution("Custom");
+  expect(config().resolution).toEqual({ width: 1000, height: 720, label: "Custom" });
+  expect(screen.getByRole("spinbutton", { name: "Width" })).toHaveValue(1000);
+});
+
+test("should persist the custom size separately from the active resolution", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const height = screen.getByRole("spinbutton", { name: "Height" });
+  await userEvent.clear(height);
+  await userEvent.type(height, "900{Enter}");
+  await selectResolution("1080×1920 (9:16)");
+  expect(config().customResolution).toEqual({ width: 1280, height: 900, label: "Custom" });
+});
+
+test("should hide custom size inputs again when a preset is picked", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  await selectResolution("1080×1920 (9:16)");
+  expect(config().resolution).toMatchObject({ width: 1080, height: 1920 });
+  expect(screen.queryByRole("spinbutton", { name: "Width" })).not.toBeInTheDocument();
+});

--- a/tests/components/app/common-config-pane.test.tsx
+++ b/tests/components/app/common-config-pane.test.tsx
@@ -223,6 +223,15 @@ test("should move focus into the width input when Custom is picked", async () =>
   expect(screen.getByRole("spinbutton", { name: "Width" })).toHaveFocus();
 });
 
+test("should return focus to the trigger when the popup is dismissed while Custom is active", async () => {
+  await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const trigger = screen.getByRole("combobox", { name: "Resolution" });
+  await userEvent.click(trigger);
+  await userEvent.keyboard("{Escape}");
+  expect(trigger).toHaveFocus();
+});
+
 test("should return focus to the trigger when a preset is picked", async () => {
   await renderCommonConfigPane();
   await selectResolution("Custom");

--- a/tests/components/app/common-config-pane.test.tsx
+++ b/tests/components/app/common-config-pane.test.tsx
@@ -251,6 +251,18 @@ test("should commit a custom size on Enter", async () => {
   expect(config().resolution.height).toBe(900);
 });
 
+test("should parse decimal and exponent input as full numbers", async () => {
+  const { config } = await renderCommonConfigPane();
+  await selectResolution("Custom");
+  const width = screen.getByRole("spinbutton", { name: "Width" });
+  await userEvent.clear(width);
+  await userEvent.type(width, "1000.5{Enter}");
+  expect(config().resolution.width).toBe(1002);
+  await userEvent.clear(width);
+  await userEvent.type(width, "1e3{Enter}");
+  expect(config().resolution.width).toBe(1000);
+});
+
 test("should restore the last committed size when the input is left empty", async () => {
   const { config } = await renderCommonConfigPane();
   await selectResolution("Custom");

--- a/tests/lib/muxer/h264-level.test.ts
+++ b/tests/lib/muxer/h264-level.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest";
+
+import { H264_MAX_MACROBLOCKS, countMacroblocks, getH264CodecString } from "@/lib/muxer/h264-level";
+
+test("countMacroblocks rounds partial 16px blocks up", () => {
+  expect(countMacroblocks({ width: 1920, height: 1080 })).toBe(120 * 68);
+  expect(countMacroblocks({ width: 16, height: 16 })).toBe(1);
+  expect(countMacroblocks({ width: 17, height: 17 })).toBe(4);
+});
+
+test("presets up to 1080p keep the existing level 4.1 codec string", () => {
+  expect(getH264CodecString({ width: 1920, height: 1080 })).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 1080, height: 1920 })).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 4096, height: 512 })).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 16, height: 16 })).toBe("avc1.42E029");
+});
+
+test("frame sizes above level 4.1 step up to the smallest fitting level", () => {
+  expect(getH264CodecString({ width: 2048, height: 1080 })).toBe("avc1.42E02A");
+  expect(getH264CodecString({ width: 2560, height: 1440 })).toBe("avc1.42E032");
+  expect(getH264CodecString({ width: 3840, height: 2160 })).toBe("avc1.42E033");
+  expect(getH264CodecString({ width: 4096, height: 2304 })).toBe("avc1.42E033");
+});
+
+test("H264_MAX_MACROBLOCKS is the level 5.1 frame size limit", () => {
+  expect(H264_MAX_MACROBLOCKS).toBe(36864);
+  expect(countMacroblocks({ width: 4096, height: 2304 })).toBe(H264_MAX_MACROBLOCKS);
+});
+
+test("frame sizes beyond the highest supported level throw", () => {
+  expect(() => getH264CodecString({ width: 4096, height: 4096 })).toThrow(
+    "exceeds H.264 level 5.1",
+  );
+});

--- a/tests/lib/muxer/h264-level.test.ts
+++ b/tests/lib/muxer/h264-level.test.ts
@@ -8,27 +8,34 @@ test("countMacroblocks rounds partial 16px blocks up", () => {
   expect(countMacroblocks({ width: 17, height: 17 })).toBe(4);
 });
 
-test("presets up to 1080p keep the existing level 4.1 codec string", () => {
-  expect(getH264CodecString({ width: 1920, height: 1080 })).toBe("avc1.42E029");
-  expect(getH264CodecString({ width: 1080, height: 1920 })).toBe("avc1.42E029");
-  expect(getH264CodecString({ width: 4096, height: 512 })).toBe("avc1.42E029");
-  expect(getH264CodecString({ width: 16, height: 16 })).toBe("avc1.42E029");
+test("presets up to 1080p30 keep the existing level 4.1 codec string", () => {
+  expect(getH264CodecString({ width: 1920, height: 1080 }, 30)).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 1080, height: 1920 }, 30)).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 4096, height: 512 }, 30)).toBe("avc1.42E029");
+  expect(getH264CodecString({ width: 16, height: 16 }, 60)).toBe("avc1.42E029");
 });
 
 test("frame sizes above level 4.1 step up to the smallest fitting level", () => {
-  expect(getH264CodecString({ width: 2048, height: 1080 })).toBe("avc1.42E02A");
-  expect(getH264CodecString({ width: 2560, height: 1440 })).toBe("avc1.42E032");
-  expect(getH264CodecString({ width: 3840, height: 2160 })).toBe("avc1.42E033");
-  expect(getH264CodecString({ width: 4096, height: 2304 })).toBe("avc1.42E033");
+  expect(getH264CodecString({ width: 2048, height: 1080 }, 30)).toBe("avc1.42E02A");
+  expect(getH264CodecString({ width: 2560, height: 1440 }, 30)).toBe("avc1.42E032");
+  expect(getH264CodecString({ width: 3840, height: 2160 }, 30)).toBe("avc1.42E033");
+  expect(getH264CodecString({ width: 4096, height: 2304 }, 30)).toBe("avc1.42E034");
 });
 
-test("H264_MAX_MACROBLOCKS is the level 5.1 frame size limit", () => {
+test("macroblock rate above the level limit steps the level up as well", () => {
+  expect(getH264CodecString({ width: 1920, height: 1080 }, 60)).toBe("avc1.42E02A");
+  expect(getH264CodecString({ width: 2560, height: 1440 }, 60)).toBe("avc1.42E033");
+  expect(getH264CodecString({ width: 3840, height: 2160 }, 60)).toBe("avc1.42E034");
+  expect(getH264CodecString({ width: 4096, height: 2304 }, 60)).toBe("avc1.42E03C");
+});
+
+test("H264_MAX_MACROBLOCKS is the frame size Chromium's encoder still accepts", () => {
   expect(H264_MAX_MACROBLOCKS).toBe(36864);
   expect(countMacroblocks({ width: 4096, height: 2304 })).toBe(H264_MAX_MACROBLOCKS);
 });
 
-test("frame sizes beyond the highest supported level throw", () => {
-  expect(() => getH264CodecString({ width: 4096, height: 4096 })).toThrow(
-    "exceeds H.264 level 5.1",
+test("frame sizes beyond the encoder ceiling throw", () => {
+  expect(() => getH264CodecString({ width: 4096, height: 4096 }, 30)).toThrow(
+    "exceeds the H.264 encoder limit",
   );
 });

--- a/tests/lib/renderers/resolution.test.ts
+++ b/tests/lib/renderers/resolution.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+
+import {
+  createCustomResolution,
+  CUSTOM_RESOLUTION_LABEL,
+  isCustomResolution,
+  MAX_RESOLUTION_SIZE,
+  MIN_RESOLUTION_SIZE,
+  resolutionGroups,
+  resolutions,
+} from "@/lib/renderers/renderer";
+
+const groupOf = (label: string) => resolutionGroups.find((g) => g.label === label)!.resolutions;
+
+test("every landscape preset has a rotated portrait counterpart", () => {
+  const landscape = groupOf("Landscape");
+  const portrait = groupOf("Portrait");
+  expect(portrait.map(({ width, height }) => ({ width, height }))).toEqual(
+    landscape.map(({ width, height }) => ({ width: height, height: width })),
+  );
+});
+
+test("portrait labels flip the aspect ratio", () => {
+  expect(groupOf("Portrait").map((r) => r.label)).toEqual([
+    "1080×1920 (9:16)",
+    "720×1280 (9:16)",
+    "480×854 (9:16)",
+    "1080×1440 (3:4)",
+    "768×1024 (3:4)",
+  ]);
+});
+
+test("flat resolutions list contains every grouped preset and keeps the 720p default second", () => {
+  expect(resolutions).toEqual(resolutionGroups.flatMap((g) => g.resolutions));
+  expect(resolutions[1]).toMatchObject({ width: 1280, height: 720 });
+});
+
+test("preset labels are unique and never collide with the custom label", () => {
+  const labels = resolutions.map((r) => r.label);
+  expect(new Set(labels).size).toBe(labels.length);
+  expect(labels).not.toContain(CUSTOM_RESOLUTION_LABEL);
+});
+
+test("createCustomResolution keeps valid even sizes as is", () => {
+  expect(createCustomResolution(1000, 600)).toEqual({
+    width: 1000,
+    height: 600,
+    label: CUSTOM_RESOLUTION_LABEL,
+  });
+});
+
+test("createCustomResolution rounds odd sizes to even", () => {
+  expect(createCustomResolution(1001, 599)).toMatchObject({ width: 1002, height: 600 });
+});
+
+test("createCustomResolution clamps sizes into the supported range", () => {
+  expect(createCustomResolution(1, 100_000)).toMatchObject({
+    width: MIN_RESOLUTION_SIZE,
+    height: MAX_RESOLUTION_SIZE,
+  });
+});
+
+test("createCustomResolution falls back to the minimum for non-finite input", () => {
+  expect(createCustomResolution(Number.NaN, Number.POSITIVE_INFINITY)).toMatchObject({
+    width: MIN_RESOLUTION_SIZE,
+    height: MAX_RESOLUTION_SIZE,
+  });
+});
+
+test("createCustomResolution shrinks the adjusted side to stay within the H.264 frame size limit", () => {
+  expect(createCustomResolution(4096, 4096, "width")).toMatchObject({
+    width: 2304,
+    height: 4096,
+  });
+  expect(createCustomResolution(4096, 4096, "height")).toMatchObject({
+    width: 4096,
+    height: 2304,
+  });
+  expect(createCustomResolution(4096, 4096)).toMatchObject({ width: 2304, height: 4096 });
+});
+
+test("createCustomResolution leaves sizes within the frame size limit untouched", () => {
+  expect(createCustomResolution(3840, 2160, "height")).toMatchObject({ width: 3840, height: 2160 });
+});
+
+test("isCustomResolution only matches the custom label", () => {
+  expect(isCustomResolution(createCustomResolution(640, 360))).toBe(true);
+  expect(isCustomResolution(resolutions[0])).toBe(false);
+});


### PR DESCRIPTION
## Summary

- Group resolution presets into **Landscape / Portrait / Square** in the Resolution select, with the portrait presets being the rotated landscape ones (e.g. `1080×1920 (9:16)`).
- Add a trailing **Custom** entry. Picking it reveals width × height inputs and moves focus into the width input. The inputs are seeded from the last custom size (`RendererConfig.customResolution`, persisted with the rest of the config) or, on first use, from the currently selected resolution.
- Custom values are committed on blur / Enter, rounded up to even numbers, clamped to 16–4096 per side, and kept within the frame size Chromium's H.264 encoder accepts (36,864 macroblocks ≈ 4096×2304) by shrinking the side being edited.
- Derive the MP4 H.264 level from the frame size and frame rate (`src/lib/muxer/h264-level.ts`) so custom sizes above 1080p encode with a valid level declaration. Level 4.1 stays the floor, so presets up to 1080p30 keep producing `avc1.42E029`; 1080p60 now declares level 4.2.

## Notes

- Verified in headless Chromium via `VideoEncoder.isConfigSupported`: Chromium validates the declared H.264 level against the frame size (MaxFS) but not the frame rate, rejects odd dimensions, and its software encoder tops out at the level 5.1 frame size regardless of the level declared. The clamp above matches that ceiling; the frame rate is still folded into the level choice so the declaration is spec-correct for decoders. VP9/WebM ignores the level and allows larger frames, but the same clamp is applied to both formats so switching format afterwards can't break MP4 export.
- The row's number inputs are deliberately not part of `FormRow`'s click-to-focus selector: with two inputs in one row, clicking the height input would otherwise jump focus to the width input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp61BaVA5FyU5RX7CbpnNb
