### PR TITLE
feat: let the mobile settings apply a waiting app update

### DIFF
--- a/src/components/app/app-update-settings.tsx
+++ b/src/components/app/app-update-settings.tsx
@@ -1,0 +1,32 @@
+import { RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/components/ui/item";
+import { usePwaContext } from "@/lib/pwa/use-pwa-context";
+
+export function AppUpdateSettings() {
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = usePwaContext();
+
+  if (!needRefresh) return null;
+
+  return (
+    <Item>
+      <ItemContent>
+        <ItemTitle>
+          App updates
+          <span aria-hidden className="inline-flex size-2.5 rounded-full bg-primary" />
+        </ItemTitle>
+        <ItemDescription>A new version is available.</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Button size="sm" onClick={() => updateServiceWorker()}>
+          <RefreshCw />
+          Update now
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/src/components/app/general-settings-content.tsx
+++ b/src/components/app/general-settings-content.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { ThemeSettings } from "./theme-settings";
+
+interface GeneralSettingsContentProps {
+  children?: ReactNode;
+}
+
+export function GeneralSettingsContent({ children }: GeneralSettingsContentProps) {
+  return (
+    <div className="space-y-4">
+      <h2 className="hidden text-lg font-semibold md:block">General</h2>
+      <ThemeSettings />
+      {children}
+    </div>
+  );
+}

--- a/src/components/app/settings-dialog.tsx
+++ b/src/components/app/settings-dialog.tsx
@@ -27,8 +27,9 @@ import {
 import { Tabs, TabsContent, TabsIndicator, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { AboutContent } from "./about-content";
+import { AppUpdateSettings } from "./app-update-settings";
+import { GeneralSettingsContent } from "./general-settings-content";
 import { KeyboardShortcutsContent } from "./keyboard-shortcuts-content";
-import { ThemeSettings } from "./theme-settings";
 
 const navGroups = [
   {
@@ -139,7 +140,7 @@ function SettingsDialogContent({
           <ScrollArea className="relative h-107.5 max-h-107.5">
             <div className="p-4">
               <Activity mode={modeForTab("general")}>
-                <ThemeSettings />
+                <GeneralSettingsContent />
               </Activity>
               <Activity mode={modeForTab("about")}>
                 <AboutContent />
@@ -169,7 +170,9 @@ export function SettingsContent({ className }: SettingsContentProps) {
       </TabsList>
       <div>
         <TabsContent value="general" className="py-4">
-          <ThemeSettings />
+          <GeneralSettingsContent>
+            <AppUpdateSettings />
+          </GeneralSettingsContent>
         </TabsContent>
         <TabsContent value="about" className="py-4">
           <AboutContent />

--- a/src/components/app/theme-settings.tsx
+++ b/src/components/app/theme-settings.tsx
@@ -19,28 +19,25 @@ export function ThemeSettings() {
   const { theme, setTheme } = useTheme();
 
   return (
-    <div className="space-y-4">
-      <h2 className="hidden text-lg font-semibold md:block">General</h2>
-      <Item>
-        <ItemContent>
-          <ItemTitle>Theme</ItemTitle>
-          <ItemDescription>Select the color theme for the application.</ItemDescription>
-        </ItemContent>
-        <ItemActions>
-          <Select value={theme} onValueChange={(value) => value && setTheme(value)} items={themes}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select theme" />
-            </SelectTrigger>
-            <SelectContent align="end">
-              {themes.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </ItemActions>
-      </Item>
-    </div>
+    <Item>
+      <ItemContent>
+        <ItemTitle>Theme</ItemTitle>
+        <ItemDescription>Select the color theme for the application.</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Select value={theme} onValueChange={(value) => value && setTheme(value)} items={themes}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select theme" />
+          </SelectTrigger>
+          <SelectContent align="end">
+            {themes.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </ItemActions>
+    </Item>
   );
 }

--- a/tests/components/app/app-update-settings.test.tsx
+++ b/tests/components/app/app-update-settings.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMockPwaState } from "tests/pwa-mock";
+import { expect, test, vi } from "vitest";
+
+import { AppUpdateSettings } from "@/components/app/app-update-settings";
+import { PwaContext, PwaState } from "@/contexts/pwa-context";
+
+function renderSettings(pwaState?: Partial<PwaState>) {
+  return render(
+    <PwaContext value={createMockPwaState(pwaState)}>
+      <AppUpdateSettings />
+    </PwaContext>,
+  );
+}
+
+test("AppUpdateSettings renders nothing when no update is waiting", () => {
+  const { container } = renderSettings();
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+test("AppUpdateSettings offers Update now when a new version is waiting", () => {
+  renderSettings({ needRefresh: [true, vi.fn<PwaState["needRefresh"][1]>()] });
+
+  expect(screen.getByRole("button", { name: "Update now" })).toBeVisible();
+  expect(screen.getByText("A new version is available.")).toBeVisible();
+});
+
+test("AppUpdateSettings calls updateServiceWorker when Update now is clicked", async () => {
+  const user = userEvent.setup();
+  const updateServiceWorker = vi.fn<PwaState["updateServiceWorker"]>();
+  renderSettings({
+    needRefresh: [true, vi.fn<PwaState["needRefresh"][1]>()],
+    updateServiceWorker,
+  });
+
+  await user.click(screen.getByRole("button", { name: "Update now" }));
+
+  expect(updateServiceWorker).toHaveBeenCalledOnce();
+});

--- a/tests/components/app/settings-dialog.test.tsx
+++ b/tests/components/app/settings-dialog.test.tsx
@@ -2,28 +2,40 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ComponentProps, useState } from "react";
 import { AudioContext } from "standardized-audio-context-mock";
+import { createMockPwaState } from "tests/pwa-mock";
 import { expect, test, vi } from "vitest";
 
 import { SettingsDialog, SettingsContent } from "@/components/app/settings-dialog";
 import { AppContext, createAppContext } from "@/contexts/app-context";
+import { PwaContext, PwaState } from "@/contexts/pwa-context";
 
 type Props = ComponentProps<typeof SettingsDialog>;
 
-// Only the app context is needed here; skipping the file-db gate keeps these renders synchronous
-function LightThemeWrapper({ children }: { children: React.ReactNode }) {
-  const [appContextValue] = useState(() =>
-    createAppContext(new AudioContext(), { defaultTheme: "light" }),
-  );
-  return <AppContext value={appContextValue}>{children}</AppContext>;
+// Only the app and PWA contexts are needed here; skipping the file-db gate keeps these renders synchronous
+function createWrapper(pwaOverrides: Partial<PwaState> = {}) {
+  return function LightThemeWrapper({ children }: { children: React.ReactNode }) {
+    const [appContextValue] = useState(() =>
+      createAppContext(new AudioContext(), { defaultTheme: "light" }),
+    );
+    const [pwaState] = useState(() => createMockPwaState(pwaOverrides));
+    return (
+      <AppContext value={appContextValue}>
+        <PwaContext value={pwaState}>{children}</PwaContext>
+      </AppContext>
+    );
+  };
 }
 
-function renderDialog(props: Partial<Props> = {}) {
+const LightThemeWrapper = createWrapper();
+const PendingUpdateWrapper = createWrapper({
+  needRefresh: [true, vi.fn<PwaState["needRefresh"][1]>()],
+});
+
+function renderDialog(props: Partial<Props> = {}, wrapper = LightThemeWrapper) {
   const onTabChange = vi.fn<Props["onTabChange"]>();
   const { rerender } = render(
     <SettingsDialog tab="general" onTabChange={onTabChange} {...props} />,
-    {
-      wrapper: LightThemeWrapper,
-    },
+    { wrapper },
   );
   return { onTabChange, rerender };
 }
@@ -54,6 +66,12 @@ test("SettingsDialog shows General content when tab is general", () => {
 
   // Theme heading should be visible in General tab
   expect(screen.getByText("Theme")).toBeVisible();
+});
+
+test("SettingsDialog leaves app updates to the footer even when an update is waiting", () => {
+  renderDialog({}, PendingUpdateWrapper);
+
+  expect(screen.queryByRole("button", { name: "Update now" })).not.toBeInTheDocument();
 });
 
 test("SettingsDialog shows About content when tab is about", () => {
@@ -158,6 +176,18 @@ test("SettingsContent shows General content by default", () => {
   render(<SettingsContent />, { wrapper: LightThemeWrapper });
 
   expect(screen.getByText("Theme")).toBeVisible();
+});
+
+test("SettingsContent offers Update now in the General tab when an update is waiting", () => {
+  render(<SettingsContent />, { wrapper: PendingUpdateWrapper });
+
+  expect(screen.getByRole("button", { name: "Update now" })).toBeVisible();
+});
+
+test("SettingsContent hides the app update control when no update is waiting", () => {
+  render(<SettingsContent />, { wrapper: LightThemeWrapper });
+
+  expect(screen.queryByText("App updates")).not.toBeInTheDocument();
 });
 
 test("SettingsContent switches to About tab when clicked", async () => {


### PR DESCRIPTION
## Summary

- On mobile the footer's "Update available" badge is hidden (`hidden md:inline-flex`), so an installed PWA had no way to apply a new version. The Settings tab icon only showed a ping indicator that led nowhere.
- The mobile inline settings (General tab) now show an **App updates** item with **Update now** whenever a service worker is waiting. It carries the same primary dot as the bottom-nav ping indicator so the two read as one signal, and calls `updateServiceWorker()`.
- The item is rendered only when `needRefresh` is true, and only in the mobile `SettingsContent`. The desktop dialog is unchanged in behavior: the footer badge remains the single place to apply an update there.
- The "General" heading moved from `ThemeSettings` into a new `GeneralSettingsContent` wrapper, which takes optional children so the mobile view can append the update item.

## Notes

- An earlier revision of this PR also added a manual "Check for updates" action (`registration.update()`) on both desktop and mobile. That was dropped after discussion: desktop is covered by the footer badge, and on mobile the ping indicator plus the conditional "Update now" item is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJMNAUQueLQXtgSJrTqt2g
