### PR TITLE
fix: keep audio playback in sync across bfcache restores

### DIFF
--- a/src/contexts/app-context.ts
+++ b/src/contexts/app-context.ts
@@ -12,6 +12,7 @@ import { createMidiSettingsStore, type MidiSettingsStore } from "@/lib/midi/midi
 import { createMidiTracksStore, type MidiTracksStore } from "@/lib/midi/midi-tracks-store";
 import { AudioPlaybackStoreImpl, type AudioPlaybackStore } from "@/lib/player/audio-playback-store";
 import { bindAnalyserSettings } from "@/lib/player/bind-analyser-settings";
+import { bindPageLifecycle } from "@/lib/player/bind-page-lifecycle";
 import {
   createRendererConfigStore,
   type RendererConfigStore,
@@ -49,6 +50,7 @@ export function createAppContext(
   const midiSettingsStore = createMidiSettingsStore();
   bindMidiTracks(fileStore.midi, midiTracksStore, midiSettingsStore);
   bindAnalyserSettings(rendererConfigStore, audioPlaybackStore);
+  bindPageLifecycle(audioPlaybackStore, audioContext);
   const visualizerEngine = new VisualizerEngine(
     audioPlaybackStore,
     createVisualizerSources({ rendererConfigStore, midiTracksStore, fileStore }),

--- a/src/lib/player/audio-playback-store.ts
+++ b/src/lib/player/audio-playback-store.ts
@@ -45,6 +45,8 @@ export interface AudioPlaybackStore {
   setVolume: (volume: number) => void;
   toggleMute: () => void;
   togglePlay: () => void;
+  play: () => void;
+  pause: () => void;
   /** Moves the position while preserving the current playing/paused state */
   seek: (time: number) => void;
   beginScrub: () => void;
@@ -262,6 +264,12 @@ export class AudioPlaybackStoreImpl
     } else {
       this.play();
     }
+  };
+
+  pause = (): void => {
+    if (!this.#source) return;
+    this.syncFromAudioContext();
+    this.stop();
   };
 
   // ============================================================

--- a/src/lib/player/bind-page-lifecycle.ts
+++ b/src/lib/player/bind-page-lifecycle.ts
@@ -1,0 +1,28 @@
+import type { AudioContext } from "standardized-audio-context";
+
+import { type AudioPlaybackStore, isEffectivelyPlaying } from "@/lib/player/audio-playback-store";
+
+export function bindPageLifecycle(
+  playback: AudioPlaybackStore,
+  audioContext: AudioContext,
+  target: Window = window,
+): () => void {
+  let wasRunning = false;
+  let wasPlaying = false;
+  const handlePageHide = () => {
+    wasRunning = audioContext.state === "running";
+    wasPlaying = isEffectivelyPlaying(playback.getSnapshot());
+    playback.pause();
+  };
+  const handlePageShow = (event: PageTransitionEvent) => {
+    if (!event.persisted) return;
+    if (wasRunning && audioContext.state === "suspended") void audioContext.resume();
+    if (wasPlaying) playback.play();
+  };
+  target.addEventListener("pagehide", handlePageHide);
+  target.addEventListener("pageshow", handlePageShow);
+  return () => {
+    target.removeEventListener("pagehide", handlePageHide);
+    target.removeEventListener("pageshow", handlePageShow);
+  };
+}

--- a/tests/lib/player/audio-playback-store.test.ts
+++ b/tests/lib/player/audio-playback-store.test.ts
@@ -359,3 +359,30 @@ test("configureAnalyser applies fft size and smoothing to the live analyser", ()
   expect(setFftSize).toHaveBeenCalledWith(512);
   expect(setSmoothing).toHaveBeenCalledWith(0.2);
 });
+
+test("pause stops playback at the position reached", async () => {
+  const { store, audioContext } = createStore();
+  const longBuffer = audioContext.createBuffer(1, 44100 * 10, 44100);
+  store.setAudioBuffer(longBuffer);
+  store.togglePlay();
+  const source = getSourceNodes(audioContext)[0];
+  const stop = vi.spyOn(source, "stop");
+  await registrar.getDeLorean(audioContext)!.travel(5);
+
+  store.pause();
+
+  expect(store.getSnapshot().status).toBe("paused");
+  expect(store.getSnapshot().position).toBe(5);
+  expect(stop).toHaveBeenCalledOnce();
+});
+
+test("pause while not playing changes nothing", () => {
+  const { store } = createStoreWithAudioBuffer();
+  const listener = vi.fn<() => void>();
+  store.subscribe(listener);
+
+  store.pause();
+
+  expect(store.getSnapshot().status).toBe("initial");
+  expect(listener).not.toHaveBeenCalled();
+});

--- a/tests/lib/player/bind-page-lifecycle.test.ts
+++ b/tests/lib/player/bind-page-lifecycle.test.ts
@@ -1,0 +1,102 @@
+import { AudioContext } from "standardized-audio-context-mock";
+import { afterEach, expect, test, vi } from "vitest";
+
+import type { PlaybackStatus } from "@/lib/player/audio-playback-store";
+import { bindPageLifecycle } from "@/lib/player/bind-page-lifecycle";
+
+import { createMockStore } from "./create-mock-store";
+
+let unbind: (() => void) | undefined;
+
+afterEach(() => {
+  unbind?.();
+  unbind = undefined;
+});
+
+function pageShow(persisted: boolean) {
+  const event = new PageTransitionEvent("pageshow");
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+}
+
+function setup(state: "running" | "suspended" = "running", status: PlaybackStatus = "paused") {
+  const playback = createMockStore({ snapshot: { status } });
+  const audioContext = new AudioContext();
+  if (state === "running") void audioContext.resume();
+  const resume = vi.spyOn(audioContext, "resume");
+  unbind = bindPageLifecycle(playback, audioContext);
+  return { playback, audioContext, resume };
+}
+
+test("pagehide pauses playback", () => {
+  const { playback } = setup();
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+
+  expect(playback.pause).toHaveBeenCalledOnce();
+});
+
+test("restoring from bfcache resumes a context that the browser suspended meanwhile", () => {
+  const { audioContext, resume } = setup();
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+  void audioContext.suspend();
+  pageShow(true);
+
+  expect(resume).toHaveBeenCalledOnce();
+});
+
+test("restoring does not resume a context that was already suspended before leaving", () => {
+  const { resume } = setup("suspended");
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+  pageShow(true);
+
+  expect(resume).not.toHaveBeenCalled();
+});
+
+test("restoring from bfcache restarts playback that pagehide interrupted", () => {
+  const { playback } = setup("running", "playing");
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+  pageShow(true);
+
+  expect(playback.play).toHaveBeenCalledOnce();
+});
+
+test("a scrub that was going to resume also restarts on restore", () => {
+  const { playback } = setup("running", "scrubbingPlaying");
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+  pageShow(true);
+
+  expect(playback.play).toHaveBeenCalledOnce();
+});
+
+test("restoring leaves playback alone when it was paused before leaving", () => {
+  const { playback } = setup("running", "paused");
+
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+  pageShow(true);
+
+  expect(playback.play).not.toHaveBeenCalled();
+});
+
+test("a fresh page load does not touch the context or playback", () => {
+  const { playback, resume } = setup("running", "playing");
+
+  pageShow(false);
+
+  expect(resume).not.toHaveBeenCalled();
+  expect(playback.play).not.toHaveBeenCalled();
+});
+
+test("unbind detaches the listeners", () => {
+  const { playback } = setup();
+
+  unbind?.();
+  unbind = undefined;
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+
+  expect(playback.pause).not.toHaveBeenCalled();
+});

--- a/tests/lib/player/create-mock-store.ts
+++ b/tests/lib/player/create-mock-store.ts
@@ -21,6 +21,8 @@ export function createMockStore(options?: { snapshot?: Partial<PlaybackSnapshot>
     scrub: vi.fn<AudioPlaybackStore["scrub"]>(),
     endScrub: vi.fn<AudioPlaybackStore["endScrub"]>(),
     togglePlay: vi.fn<AudioPlaybackStore["togglePlay"]>(),
+    play: vi.fn<AudioPlaybackStore["play"]>(),
+    pause: vi.fn<AudioPlaybackStore["pause"]>(),
     setVolume: vi.fn<AudioPlaybackStore["setVolume"]>(),
     toggleMute: vi.fn<AudioPlaybackStore["toggleMute"]>(),
     syncFromAudioContext: vi.fn<AudioPlaybackStore["syncFromAudioContext"]>(),


### PR DESCRIPTION
## Summary

Returning to mivi through the back/forward cache (bfcache) desynced the audio player: the playhead position is derived from `AudioContext.currentTime` against a start time captured before the page was frozen, so on restore the position jumped while the UI still reported "playing" (the `AudioBufferSourceNode` survived the freeze, and no code path ever resumed the context).

This PR makes bfcache restores transparent to the listener:

- `pagehide` pauses playback at the position reached, remembering whether the context was running and whether playback was in progress.
- A persisted `pageshow` resumes the `AudioContext` if the browser suspended it meanwhile, and restarts playback when it was playing at `pagehide`.
- `AudioPlaybackStore` gains a public `pause()` and exposes the existing `play()` on its interface.

Pausing at `pagehide` also stops the visualizer's rAF loop, so no separate catch-up repaint or frame-pacing fix is needed on restore. The audit found no hard bfcache blockers in the app (no `unload`/`beforeunload`, no long-lived connections, no persistent IndexedDB connection, GitHub Pages cannot send `Cache-Control: no-store`).

## Known limitation

Chrome permanently disables bfcache for a document once an `<input type="file">` chooser has been opened (`FileChooserImpl::OpenFileChooser` → `BackForwardCache::DisableForRenderFrameHost(kFileChooser)`, documented as "can not be undone"). Right after picking a file, Back navigation therefore does a full reload, which restores from OPFS as before. Drag-and-drop and `showOpenFilePicker` do not go through that path; switching the picker is out of scope here.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] Unit tests: 838 passed, including new `pause()` tests and `bind-page-lifecycle` tests (pagehide pauses; persisted pageshow resumes a suspended context and restarts playback; paused playback and fresh loads are left alone; unbind detaches listeners)
- [x] Real bfcache round-trip against a production build (`vite preview`) in Chromium with bfcache enabled, playing `tests/fixtures/test.mp3`, navigating to a cross-host page and back: `pageshow.persisted === true`, no `backForwardCacheNotUsed` reasons, playback continued from 1.54 s → 2.18 s at restore and advanced 1 s per second afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAC3FwfsEoKpfB5egKEULK
