### PR TITLE
chore: replace the clsx + tailwind-merge cn helper with the cn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tonejs/midi": "^2.0.28",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.6",
     "colorjs.io": "^0.7.1",
     "comlink": "^4.4.2",
     "es-toolkit": "^1.51.0",
@@ -37,7 +37,6 @@
     "react-error-boundary": "^6.1.4",
     "react-hotkeys-hook": "^5.3.3",
     "standardized-audio-context": "^25.3.77",
-    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,9 +240,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.6
+        version: 0.2.6
       colorjs.io:
         specifier: ^0.7.1
         version: 0.7.1
@@ -273,9 +273,6 @@ importers:
       standardized-audio-context:
         specifier: ^25.3.77
         version: 25.3.77
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -2940,8 +2937,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cn@0.2.5:
-    resolution: {integrity: sha512-OCjZtMeQfXbI4Es1+EIjkd77gvWzaE689gD8KhfexlqjClC06qR1MQBR+Z35ZMSPNEBWyHiItW1Soy0UvwNv9w==}
+  cn@0.2.6:
+    resolution: {integrity: sha512-+i4L0zUGgRcEnhsxueVrP7iBGxBx5iD0WOTYg1MwFEu2ZyCmH5Ov2V1cul2Ht5UchRQQgftCf4be/RxspuW6QQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -5006,9 +5003,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -7901,7 +7895,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cn@0.2.5: {}
+  cn@0.2.6: {}
 
   code-block-writer@13.0.3: {}
 
@@ -9876,7 +9870,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.30.0(supports-color@7.2.0)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.7
-      cn: 0.2.5
+      cn: 0.2.6
       commander: 14.0.3
       cosmiconfig: 9.0.2(typescript@7.0.2)
       dedent: 1.7.2
@@ -10150,8 +10144,6 @@ snapshots:
 
   tagged-tag@1.0.0:
     optional: true
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useState } from "react";
 
 import { AppHeader } from "@/components/app/app-header";
@@ -25,7 +26,6 @@ import { Toaster } from "@/components/ui/toast";
 import { useAppContext } from "@/contexts/app-context";
 import { useStore } from "@/hooks/use-store";
 import { useVisualizerFit } from "@/hooks/use-visualizer-fit";
-import { cn } from "@/lib/utils";
 
 const PANELS: PanelConfig[] = [
   { id: "track-list", defaultSize: 300, constraints: { minSize: 200 } },

--- a/src/components/app/about-content.tsx
+++ b/src/components/app/about-content.tsx
@@ -1,9 +1,9 @@
+import { cn } from "cn";
 import { CircleCheck, CircleX, Info } from "lucide-react";
 import { useMemo } from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { checkBrowserApis } from "@/lib/browser-compat/browser-compat";
-import { cn } from "@/lib/utils";
 
 interface Props {
   className?: string;

--- a/src/components/app/app-header.tsx
+++ b/src/components/app/app-header.tsx
@@ -1,5 +1,6 @@
+import { cn } from "cn";
+
 import { ExportButton } from "@/components/app/export-button";
-import { cn } from "@/lib/utils";
 
 interface Props {
   className?: string;

--- a/src/components/app/canvas.tsx
+++ b/src/components/app/canvas.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { useLayoutEffect, useRef } from "react";
 
 import { useAppContext } from "@/contexts/app-context";
-import { cn } from "@/lib/utils";
 
 interface Props {
   className?: string;

--- a/src/components/app/footer-panel.tsx
+++ b/src/components/app/footer-panel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { Download, RefreshCw, Settings } from "lucide-react";
 import { memo } from "react";
 
@@ -5,7 +6,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { usePwaContext } from "@/lib/pwa/use-pwa-context";
-import { cn } from "@/lib/utils";
 
 interface Props {
   className?: string;

--- a/src/components/app/hue-randomize-dialog.tsx
+++ b/src/components/app/hue-randomize-dialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useState, useCallback, useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -14,7 +15,6 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { HSL_PRESETS, HSLPresetBase, hslToHex } from "@/lib/colors/color";
-import { cn } from "@/lib/utils";
 
 interface Props {
   open: boolean;

--- a/src/components/app/mobile-bottom-nav.tsx
+++ b/src/components/app/mobile-bottom-nav.tsx
@@ -1,9 +1,9 @@
 import { Tabs as TabsPrimitive } from "@base-ui/react";
+import { cn } from "cn";
 import { ListMusic, Music, Palette, Settings } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { usePwaContext } from "@/lib/pwa/use-pwa-context";
-import { cn } from "@/lib/utils";
 
 const tabs = [
   {

--- a/src/components/app/player-controls.tsx
+++ b/src/components/app/player-controls.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { Pause, Play, Volume2, VolumeX } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -5,7 +6,7 @@ import { Slider } from "@/components/ui/slider";
 import { useAppContext } from "@/contexts/app-context";
 import { useStore } from "@/hooks/use-store";
 import { isEffectivelyPlaying } from "@/lib/player/audio-playback-store";
-import { cn, formatTime } from "@/lib/utils";
+import { formatTime } from "@/lib/utils";
 import { type FpsCounter } from "@/lib/visualizer/fps-counter";
 
 interface InteractionProps {

--- a/src/components/app/track-item.tsx
+++ b/src/components/app/track-item.tsx
@@ -1,5 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { cn } from "cn";
 import { GripVertical } from "lucide-react";
 import React from "react";
 
@@ -8,7 +9,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { MidiTrack } from "@/lib/midi/midi";
-import { cn } from "@/lib/utils";
 
 interface Props {
   track: MidiTrack;

--- a/src/components/app/visualizer-player.tsx
+++ b/src/components/app/visualizer-player.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { Maximize, Minimize } from "lucide-react";
 import { useCallback } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -16,7 +17,6 @@ import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/contexts/app-context";
 import { usePanelVisibility } from "@/hooks/use-panel-visibility";
 import { useStore } from "@/hooks/use-store";
-import { cn } from "@/lib/utils";
 
 // ARIA widget roles where Space has a native interaction (activate, toggle, type, etc.).
 // "slider" is intentionally excluded so Space toggles playback even when a slider is focused.

--- a/src/components/common/color-picker-input.tsx
+++ b/src/components/common/color-picker-input.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { useCallback, useId, useState } from "react";
 
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
-import { cn } from "@/lib/utils";
 
 interface ColorPickerInputProps {
   value: string;

--- a/src/components/common/file-button.tsx
+++ b/src/components/common/file-button.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CircleXIcon } from "lucide-react";
 import { useCallback, useId, useRef } from "react";
 
@@ -8,7 +9,6 @@ import {
   InputGroupText,
 } from "@/components/ui/input-group";
 import { Spinner } from "@/components/ui/spinner";
-import { cn } from "@/lib/utils";
 
 interface Props {
   filename: string | undefined;

--- a/src/components/common/select-row.tsx
+++ b/src/components/common/select-row.tsx
@@ -1,7 +1,7 @@
 import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { cn } from "cn";
 
 import { Select, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
 
 type Props<Value, Multiple extends boolean | undefined> = SelectPrimitive.Root.Props<
   Value,

--- a/src/components/grid-resizable/grid-resizable-panel-group.tsx
+++ b/src/components/grid-resizable/grid-resizable-panel-group.tsx
@@ -1,6 +1,5 @@
+import { cn } from "cn";
 import type { ComponentProps, ReactNode } from "react";
-
-import { cn } from "@/lib/utils";
 
 import { GridResizableContext } from "./grid-resizable-context";
 import type { PanelConfig } from "./types";

--- a/src/components/grid-resizable/grid-resizable-panel.tsx
+++ b/src/components/grid-resizable/grid-resizable-panel.tsx
@@ -1,6 +1,5 @@
+import { cn } from "cn";
 import { useCallback } from "react";
-
-import { cn } from "@/lib/utils";
 
 import { useGridResizableContext } from "./grid-resizable-context";
 import { getPanelElementId } from "./panel-element-id";

--- a/src/components/grid-resizable/grid-resizable-separator.tsx
+++ b/src/components/grid-resizable/grid-resizable-separator.tsx
@@ -1,6 +1,5 @@
+import { cn } from "cn";
 import { useCallback } from "react";
-
-import { cn } from "@/lib/utils";
 
 import { useGridResizableContext } from "./grid-resizable-context";
 import { getPanelElementId } from "./panel-element-id";

--- a/src/components/providers/loading.tsx
+++ b/src/components/providers/loading.tsx
@@ -1,8 +1,9 @@
+import { cn } from "cn";
 import { useState, useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/contexts/app-context";
-import { cn, resetConfig } from "@/lib/utils";
+import { resetConfig } from "@/lib/utils";
 
 export function Loading() {
   const { fileStore } = useAppContext();

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
   "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 const badgeVariants = cva(
   "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,9 +1,9 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 
 import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 
 const buttonGroupVariants = cva(
   "flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,6 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,7 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const cardVariants = cva(
   "group/card flex flex-col gap-6 overflow-hidden rounded-xl py-6 text-sm text-card-foreground has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,7 +1,6 @@
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import { cn } from "cn";
 import { CheckIcon } from "lucide-react";
-
-import { cn } from "@/lib/utils";
 
 function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
   return (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,9 +1,9 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { cn } from "cn";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,7 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { cn } from "cn";
 import { ChevronRightIcon, CheckIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
   return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,10 +1,10 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
 
 function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,6 @@
 import { Input as InputPrimitive } from "@base-ui/react/input";
+import { cn } from "cn";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -1,10 +1,10 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import * as React from "react";
 
 import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   return (

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -1,5 +1,6 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { Menubar as MenubarPrimitive } from "@base-ui/react/menubar";
+import { cn } from "cn";
 import { CheckIcon } from "lucide-react";
 import * as React from "react";
 
@@ -18,7 +19,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { cn } from "@/lib/utils";
 
 function Menubar({ className, ...props }: MenubarPrimitive.Props) {
   return (

--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -1,8 +1,8 @@
 import { NumberField as NumberFieldPrimitive } from "@base-ui/react/number-field";
+import { cn } from "cn";
 import { MinusIcon, PlusIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 function NumberField(props: NumberFieldPrimitive.Root.Props) {
   return <NumberFieldPrimitive.Root data-slot="number-field" {...props} />;

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Progress({ className, children, value, ...props }: ProgressPrimitive.Root.Props) {
   return (

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 interface Props extends ScrollAreaPrimitive.Root.Props {
   orientation?: "horizontal" | "vertical" | "both";

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,8 +1,7 @@
 import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { cn } from "cn";
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const Select = SelectPrimitive.Root;
 

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,6 +1,5 @@
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
   return (

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,9 +1,9 @@
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+import { cn } from "cn";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,6 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { PanelLeftIcon } from "lucide-react";
 import * as React from "react";
 
@@ -19,7 +20,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSidebar } from "@/components/ui/use-sidebar";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { cn } from "@/lib/utils";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,7 +1,6 @@
 import { Slider as SliderPrimitive } from "@base-ui/react/slider";
+import { cn } from "cn";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 type SliderProps = Omit<SliderPrimitive.Root.Props, "onValueChange" | "onValueCommitted"> & {
   onValueChange?: (value: number[], eventDetails: SliderPrimitive.Root.ChangeEventDetails) => void;

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,6 +1,5 @@
+import { cn } from "cn";
 import { Loader2Icon } from "lucide-react";
-
-import { cn } from "@/lib/utils";
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,6 +1,5 @@
 import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Switch({
   className,

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,6 @@
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive.Root.Props) {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,5 @@
+import { cn } from "cn";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,6 +5,7 @@ import {
   type ToastManagerAddOptions,
   type ToastManagerUpdateOptions,
 } from "@base-ui/react/toast";
+import { cn } from "cn";
 import {
   CircleCheckIcon,
   InfoIcon,
@@ -16,7 +17,6 @@ import {
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 export type ToastType = "success" | "info" | "warning" | "error" | "loading" | (string & {});
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,5 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
-
-import { cn } from "@/lib/utils";
+import { cn } from "cn";
 
 function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
   return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />;

--- a/src/hooks/use-dnd.tsx
+++ b/src/hooks/use-dnd.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useState, useCallback, useMemo, type DragEvent } from "react";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -5,7 +6,6 @@ import { useSetAudioFile } from "@/lib/audio/use-audio";
 import { useSetBackgroundImageFile } from "@/lib/background-image/use-background-image";
 import { errorLogWithToast } from "@/lib/error-toast";
 import { useSetMidiFile } from "@/lib/midi/use-midi";
-import { cn } from "@/lib/utils";
 
 export function useDnd() {
   const setMidiFile = useSetMidiFile();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,6 @@
-import { clsx, type ClassValue } from "clsx";
 import { flushSync } from "react-dom";
-import { twMerge } from "tailwind-merge";
 
 import type { FileStore } from "@/lib/file-store/file-store";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
 
 export function formatTime(timeInSeconds: number): string {
   const minutes = Math.floor(timeInSeconds / 60);

--- a/src/lib/visualizer/visualizer-engine.ts
+++ b/src/lib/visualizer/visualizer-engine.ts
@@ -1,10 +1,11 @@
+import { cn } from "cn";
+
 import { SerializedAudio } from "@/lib/audio/audio";
 import { computeFFTAtTime } from "@/lib/audio/fft-precompute";
 import { MidiTracks } from "@/lib/midi/midi";
 import type { AudioPlaybackStore } from "@/lib/player/audio-playback-store";
 import { RendererConfig } from "@/lib/renderers/renderer";
 import type { ReadableStore } from "@/lib/store/observable-store";
-import { cn } from "@/lib/utils";
 import { FpsCounter } from "@/lib/visualizer/fps-counter";
 import { RendererController } from "@/lib/visualizer/renderer-controller";
 

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -3,15 +3,7 @@ import { describe, it, expect, beforeEach, vi, test } from "vitest";
 
 import { FileStore } from "@/lib/file-store/file-store";
 import { MemoryFileStorage } from "@/lib/file-store/memory-file-storage";
-import { cn, formatTime, resetConfig, startViewTransition } from "@/lib/utils";
-
-describe("cn", () => {
-  it("should merge class names correctly", () => {
-    expect(cn("class1", "class2")).toBe("class1 class2");
-    expect(cn("class1", null, undefined, "class2")).toBe("class1 class2");
-    expect(cn("class1", { class2: true, class3: false })).toBe("class1 class2");
-  });
-});
+import { formatTime, resetConfig, startViewTransition } from "@/lib/utils";
 
 describe("formatTime", () => {
   it("should format time correctly", () => {


### PR DESCRIPTION
## Summary

- Follows the shadcn changelog (https://ui.shadcn.com/docs/changelog): replaces the local `twMerge(clsx(...))` helper with the dependency-free `cn` package and removes `clsx` and `tailwind-merge` from the direct dependencies. `clsx` remains in the lockfile only as a transitive dependency of `class-variance-authority`.
- Every `import { cn } from "@/lib/utils"` (47 files across `src/`) now imports `cn` from the `cn` package directly, and the re-export is dropped from `src/lib/utils.ts`.
- The `cn` unit test in `tests/lib/utils.test.ts` is removed because it only exercised the third-party package. The other helpers in `src/lib/utils.ts` (`formatTime`, `resetConfig`, `startViewTransition`) are untouched.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm knip`: clean
- `pnpm vitest run`: 991 passed, 1 skipped
- `pnpm build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pv8Whz75aq8ayG1bDSmsW