### PR TITLE
fix: derive the piano roll press animation from time instead of frame history

### DIFF
--- a/src/lib/renderers/piano-roll/piano-roll-renderer.ts
+++ b/src/lib/renderers/piano-roll/piano-roll-renderer.ts
@@ -3,8 +3,12 @@ import { MidiTrack } from "@/lib/midi/midi";
 import { Renderer, RendererConfig } from "@/lib/renderers/renderer";
 import { findFirstVisibleNoteIndex } from "@/lib/renderers/shared/find-first-visible-note";
 import { NoiseTextureRenderer } from "@/lib/renderers/shared/noise-texture-renderer";
+import { computePressOffset } from "@/lib/renderers/shared/note-press";
 import { drawRipple } from "@/lib/renderers/shared/ripple";
 import { RoughRectDrawer } from "@/lib/renderers/shared/rough-rect-drawer";
+
+// Keeps a note "touched" for a few pixels past its right edge so short notes still register
+const PLAYHEAD_TOUCH_SLACK_PX = 20;
 
 export class PianoRollRenderer extends Renderer {
   readonly #overflowFactor = 0.5;
@@ -30,14 +34,6 @@ export class PianoRollRenderer extends Renderer {
       isDurationMode: boolean;
       hasCompleted: boolean;
       wasTouchingPlayhead: boolean;
-    }
-  >();
-
-  #pressStates = new Map<
-    number,
-    {
-      startTime: number;
-      isPressed: boolean;
     }
   >();
 
@@ -67,7 +63,6 @@ export class PianoRollRenderer extends Renderer {
     if (currentTime < this.#lastCurrentTime) {
       this.#rippleStates.clear();
       this.#noteFlashStates.clear();
-      this.#pressStates.clear();
     }
     this.#lastCurrentTime = currentTime;
 
@@ -106,6 +101,7 @@ export class PianoRollRenderer extends Renderer {
       const rightEdgeTime = currentTime + (endTime - currentTime) / scale;
       const scaledOverflow =
         (this.config.pianoRollConfig.timeWindow * this.#overflowFactor) / scale;
+      const pxPerSecond = (width * scale) / this.config.pianoRollConfig.timeWindow;
 
       // Binary search to skip notes that end before the visible range
       const startIdx = findFirstVisibleNoteIndex(track.notes, leftEdgeTime - scaledOverflow);
@@ -137,48 +133,23 @@ export class PianoRollRenderer extends Renderer {
         const y = this.#noteToY(note.midi) + verticalMargin;
 
         const noteKey = note.id;
-        const isTouchingPlayhead = Math.abs(x - playheadX) < noteWidth + 20 && playheadX > x;
+        const touchEnd = noteStart + (noteWidth + PLAYHEAD_TOUCH_SLACK_PX) / pxPerSecond;
+        const isTouchingPlayhead = currentTime > noteStart && currentTime < touchEnd;
         const wasNotTouchingPlayhead = !this.#noteFlashStates.has(noteKey);
-
-        // Update press state (only when press effect is enabled)
-        if (this.config.pianoRollConfig.showNotePressEffect) {
-          if (!this.#pressStates.has(noteKey)) {
-            this.#pressStates.set(noteKey, {
-              startTime: currentTime,
-              isPressed: isTouchingPlayhead,
-            });
-          } else if (this.#pressStates.get(noteKey)!.isPressed !== isTouchingPlayhead) {
-            this.#pressStates.set(noteKey, {
-              startTime: currentTime,
-              isPressed: isTouchingPlayhead,
-            });
-          }
-        }
 
         // Draw note with effects
         this.ctx.fillStyle = track.config.color;
         this.ctx.globalAlpha = track.config.opacity;
 
-        // Calculate press offset with animation
-        let pressOffset = 0;
-        if (this.config.pianoRollConfig.showNotePressEffect) {
-          const pressState = this.#pressStates.get(noteKey)!;
-          const pressProgress = Math.min(
-            1,
-            (currentTime - pressState.startTime) /
+        const pressOffset = this.config.pianoRollConfig.showNotePressEffect
+          ? -computePressOffset(
+              noteStart,
+              touchEnd,
               this.config.pianoRollConfig.pressAnimationDuration,
-          );
-          const targetOffset = this.config.pianoRollConfig.notePressDepth;
-          const currentOffset = pressState.isPressed
-            ? pressProgress * targetOffset
-            : targetOffset * (1 - pressProgress);
-          pressOffset = -currentOffset;
-
-          // Clean up completed release animations
-          if (!pressState.isPressed && pressProgress >= 1) {
-            this.#pressStates.delete(noteKey);
-          }
-        }
+              this.config.pianoRollConfig.notePressDepth,
+              currentTime,
+            )
+          : 0;
 
         if (
           this.config.pianoRollConfig.showNoteFlash &&

--- a/src/lib/renderers/shared/note-press.ts
+++ b/src/lib/renderers/shared/note-press.ts
@@ -1,0 +1,18 @@
+// Pure function of time so scrubbing or reverse playback lands on the same frame as forward playback
+export function computePressOffset(
+  pressStart: number,
+  pressEnd: number,
+  animationDuration: number,
+  depth: number,
+  currentTime: number,
+): number {
+  if (currentTime < pressStart) return 0;
+
+  const ramp = (elapsed: number) =>
+    animationDuration > 0 ? Math.min(1, elapsed / animationDuration) : 1;
+
+  if (currentTime < pressEnd) return depth * ramp(currentTime - pressStart);
+
+  const depthAtRelease = depth * ramp(pressEnd - pressStart);
+  return depthAtRelease * (1 - ramp(currentTime - pressEnd));
+}

--- a/tests/lib/renderers/piano-roll/piano-roll-renderer.test.ts
+++ b/tests/lib/renderers/piano-roll/piano-roll-renderer.test.ts
@@ -1,0 +1,71 @@
+import { expect, test, vi } from "vitest";
+
+import { MidiTrack, getDefaultTrackConfig } from "@/lib/midi/midi";
+import { PianoRollRenderer } from "@/lib/renderers/piano-roll/piano-roll-renderer";
+import { RendererConfig, getDefaultRendererConfig } from "@/lib/renderers/renderer";
+
+function setup(overrides: Partial<RendererConfig["pianoRollConfig"]> = {}) {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d")!;
+  const defaults = getDefaultRendererConfig();
+  const config: RendererConfig = {
+    ...defaults,
+    type: "pianoRoll",
+    resolution: { width: 800, height: 600, label: "800×600" },
+    pianoRollConfig: { ...defaults.pianoRollConfig, ...overrides },
+  };
+  const renderer = new PianoRollRenderer(ctx, config);
+  return { ctx, renderer };
+}
+
+const track: MidiTrack = {
+  id: "t",
+  sourceIndex: 0,
+  config: getDefaultTrackConfig("t"),
+  notes: [
+    {
+      id: 1,
+      midi: 60,
+      time: 2,
+      duration: 0.5,
+      velocity: 1,
+      name: "C4",
+      ticks: 0,
+      durationTicks: 0,
+    },
+  ],
+};
+
+function noteYAt(renderer: PianoRollRenderer, ctx: CanvasRenderingContext2D, time: number) {
+  vi.mocked(ctx.roundRect).mockClear();
+  renderer.render([track], time);
+  return vi.mocked(ctx.roundRect).mock.calls[0][1];
+}
+
+test("keeps an unpressed note at the same y across frames", () => {
+  const { ctx, renderer } = setup({
+    showNotePressEffect: true,
+    notePressDepth: 4,
+    pressAnimationDuration: 0.1,
+  });
+  const ys = new Set<number>();
+  for (let frame = 0; frame < 20; frame++) {
+    ys.add(noteYAt(renderer, ctx, frame / 60));
+  }
+  expect(ys.size).toBe(1);
+});
+
+test("keeps a released note at its resting y once the release animation ends", () => {
+  const { ctx, renderer } = setup({
+    showNotePressEffect: true,
+    notePressDepth: 4,
+    pressAnimationDuration: 0.1,
+  });
+  const restingY = noteYAt(renderer, ctx, 0);
+  noteYAt(renderer, ctx, 2.1);
+  const ys = new Set<number>();
+  for (let frame = 0; frame < 20; frame++) {
+    ys.add(noteYAt(renderer, ctx, 3 + frame / 60));
+  }
+  expect(ys).toEqual(new Set([restingY]));
+});

--- a/tests/lib/renderers/piano-roll/piano-roll-renderer.test.ts
+++ b/tests/lib/renderers/piano-roll/piano-roll-renderer.test.ts
@@ -69,3 +69,25 @@ test("keeps a released note at its resting y once the release animation ends", (
   }
   expect(ys).toEqual(new Set([restingY]));
 });
+
+test("sinks a pressed note by notePressDepth once the press animation completes", () => {
+  const { ctx, renderer } = setup({
+    showNotePressEffect: true,
+    notePressDepth: 4,
+    pressAnimationDuration: 0.1,
+  });
+  const restingY = noteYAt(renderer, ctx, 0);
+  expect(noteYAt(renderer, ctx, 2.2)).toBeCloseTo(restingY + 4);
+});
+
+test("renders the same y for a time no matter which direction playback reached it", () => {
+  const times = Array.from({ length: 40 }, (_, i) => 1.9 + i * 0.025);
+  const forward = setup({ showNotePressEffect: true });
+  const backward = setup({ showNotePressEffect: true });
+  const forwardYs = times.map((t) => noteYAt(forward.renderer, forward.ctx, t));
+  const backwardYs = times
+    .toReversed()
+    .map((t) => noteYAt(backward.renderer, backward.ctx, t))
+    .toReversed();
+  expect(backwardYs).toEqual(forwardYs);
+});

--- a/tests/lib/renderers/shared/note-press.test.ts
+++ b/tests/lib/renderers/shared/note-press.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest";
+
+import { computePressOffset } from "@/lib/renderers/shared/note-press";
+
+const depth = 4;
+const duration = 0.1;
+
+test("returns 0 before the press starts", () => {
+  expect(computePressOffset(2, 2.5, duration, depth, 1.9)).toBe(0);
+});
+
+test("ramps down to the full depth while pressed", () => {
+  expect(computePressOffset(2, 2.5, duration, depth, 2)).toBe(0);
+  expect(computePressOffset(2, 2.5, duration, depth, 2.05)).toBeCloseTo(depth / 2);
+  expect(computePressOffset(2, 2.5, duration, depth, 2.1)).toBeCloseTo(depth);
+  expect(computePressOffset(2, 2.5, duration, depth, 2.3)).toBeCloseTo(depth);
+});
+
+test("ramps back to rest after the press ends", () => {
+  expect(computePressOffset(2, 2.5, duration, depth, 2.55)).toBeCloseTo(depth / 2);
+  expect(computePressOffset(2, 2.5, duration, depth, 2.6)).toBe(0);
+  expect(computePressOffset(2, 2.5, duration, depth, 5)).toBe(0);
+});
+
+test("releases from the depth actually reached by a short press", () => {
+  expect(computePressOffset(2, 2.05, duration, depth, 2.05)).toBeCloseTo(depth / 2);
+  expect(computePressOffset(2, 2.05, duration, depth, 2.1)).toBeCloseTo(depth / 4);
+  expect(computePressOffset(2, 2.05, duration, depth, 2.15)).toBe(0);
+});
+
+test("snaps without a ramp when the animation duration is 0", () => {
+  expect(computePressOffset(2, 2.5, 0, depth, 2)).toBe(depth);
+  expect(computePressOffset(2, 2.5, 0, depth, 2.5)).toBe(0);
+});


### PR DESCRIPTION
## Summary

The piano roll press animation was a per-note state machine keyed on the previous frame. That caused two problems:

- Every unpressed note re-created its state at full `notePressDepth` once the release ramp finished, so all visible notes bobbed by 4px on a `pressAnimationDuration + 1 frame` cycle (the jitter reported in preview).
- Scrubbing the slider or playing backwards replayed animations, because the offset depended on playback history rather than time.

This PR makes the press offset a pure function of `currentTime`:

- The touch window is now expressed in seconds (note start → note width + 20px slack converted via px/s), and `isTouchingPlayhead` is derived from the same window so press, flash and ripple share one boundary.
- `computePressOffset` (new, `src/lib/renderers/shared/note-press.ts`) ramps in from the press start and ramps out from whatever depth the press actually reached, so short presses no longer snap to full depth on release.
- `#pressStates` and its rewind clear are removed.

Flash and ripple still use the old stateful pattern; they can get the same treatment in a follow-up.

## Test plan

- [x] `tests/lib/renderers/shared/note-press.test.ts`: before press, ramp in, ramp out, short press release, zero-duration snap
- [x] `tests/lib/renderers/piano-roll/piano-roll-renderer.test.ts`: unpressed note keeps a constant y, released note returns to rest, pressed note sinks by `notePressDepth`, forward and reversed time sequences render identical y values
- [x] Full unit suite (837 tests), `tsc -b`, `oxlint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TGvLRo4dFZUQ2C1QeTW
